### PR TITLE
Refactor lib to use gulp streams. Improve tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
 - '0.10'
 script:
-- ./node_modules/gulp/bin/gulp.js build
+- ./node_modules/gulp/bin/gulp.js build && npm test
 notifications:
   email: false
   slack:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To install as a global command line tool
 
 How to use from command line
 
-    styleguide -s <source_path> -o <output_path> [-c <config_file>] [--server]
+    styleguide -s <source_path> -o <output_path> [-c <config_file>] [--server] [--watch]
 
 **-s, --source**
 
@@ -65,7 +65,6 @@ To use in gulp
     gulp.task("styleguide", function() {
       return gulp.src(["/**/*.css", "**/*.scss", "**/*.less"])
         .pipe(styleguide({
-            outputPath: "<destination path>",
             overviewPath: "<path to your overview.md>",
             extraHead: [
                 "<link rel=\"stylesheet\" type=\"text/css\" href=\"your/custom/style.css\">",
@@ -74,7 +73,8 @@ To use in gulp
             sass: {
                 // Options passed to gulp-ruby-sass
             },
-          }));
+          }))
+        .pipe(gulp.dest("<destination path>"));
     });
 
 ## How to develop
@@ -86,10 +86,14 @@ Start watching UI changes in lib/app and build the app using the demo stylesheet
 
 Running the task also runs a small development server
 
+### Running tests
+
+    npm test
+
 ### Coding convention
 
 This project follows AirBNB-ish JavaScript coding convention (with a few changes). It is tuned to use [JSCS]() as a code
-checker. The checking is injected into the build process, so you can see in Travis respond to your pull-request if your
+checker. The checking is injected into the testing process, so you can see in Travis respond to your pull-request if your
 files follow the convention.
 
 To be able to check during development, please

--- a/bin/styleguide
+++ b/bin/styleguide
@@ -46,15 +46,15 @@ gulp.task('styleguide', function() {
   if (config.overviewPath) {
     overviewPath = path.resolve(path.dirname(argv.config), config.overviewPath);
   }
-  return gulp.src(sourceFiles)
+  gulp.src(sourceFiles)
     .pipe(styleguide({
       extraHead: config.extraHead,
-      outputPath: outputPath,
       overviewPath: overviewPath,
       sass: {
         loadPath: neat.includePaths
       }
-    }));
+    }))
+    .pipe(gulp.dest(outputPath));
 });
 
 gulp.task('serve', function() {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -49,12 +49,12 @@ gulp.task('styleguide', function() {
   return gulp.src([sourcePath + '/**/*.scss'])
     .pipe(styleguide({
       extraHead: config.extraHead,
-      outputPath: outputPath,
       overviewPath: overviewPath,
       sass: {
         loadPath: neat.includePaths
       }
-    }));
+    }))
+    .pipe(gulp.dest(outputPath));
 });
 
 gulp.task('js:app', function() {
@@ -119,4 +119,4 @@ gulp.task('watch', ['serve'], function() {
   gulp.watch(sourcePath + '/**', ['styleguide']);
 });
 
-gulp.task('build', ['jscs', 'sass', 'js:app', 'js:vendor', 'html', 'assets']);
+gulp.task('build', ['sass', 'js:app', 'js:vendor', 'html', 'assets']);

--- a/lib/styleguide.js
+++ b/lib/styleguide.js
@@ -9,21 +9,24 @@
 ***/
 
 'use strict';
-var through2 = require('through2'),
+var through = require('through2'),
   kss = require('kss'),
   sanitizeHtml = require('sanitize-html'),
   fs = require('fs'),
   ncp = require('ncp'),
   vfs = require('vinyl-fs'),
-  sass = require('gulp-ruby-sass'),
+  gulp = require('gulp'),
+  sass = require('gulp-sass'),
   less = require('gulp-less'),
   concat = require('gulp-concat'),
   filter = require('gulp-filter'),
   es = require('event-stream'),
   chalk = require('chalk'),
-  marked = require('marked'),
+  marked = require('gulp-marked'),
   mkdirp = require('mkdirp'),
-  renderer = new marked.Renderer();
+  File = require('vinyl'),
+  distPath = __dirname + '/dist',
+  callbackCount;
 
 module.exports = function(opt) {
   if (!opt) opt = {};
@@ -41,7 +44,16 @@ module.exports = function(opt) {
     settingsRe = new RegExp('_styleguide_variables.scss');
 
   // A stream through which each file will pass
-  return through2(
+  // We have 3 different streams that we have to wait until the whole process is completed
+  callbackCount = 3;
+
+  var checkIfDone = function(callback) {
+    if (--callbackCount <= 0) {
+      callback();
+    }
+  }
+
+  return through(
     {
       objectMode: true,
       allowHalfOpen: false
@@ -55,7 +67,7 @@ module.exports = function(opt) {
 
       if (settingsRe.test(file.path)) {
         console.log('_styleguide_variables.scss found! Generating settings.');
-        settingsStr = String(file.contents);
+        settingsStr = file.contents.toString();
       }
 
       filesBuffer[file.path] = file.contents.toString('utf8');
@@ -67,126 +79,126 @@ module.exports = function(opt) {
       cb();
     },
     // After reading all files, parse them and generate data for styleguide
-    function(cb) {
-      var overviewPath, styleguide = jsonStyleGuide(filesBuffer, opt.kssOpt);
-
-      // If settings file is found, generate settings object
-      if (settingsStr) {
-        styleguide.settings = parseSettings(settingsStr);
-      }
-
-      // Create destination folder
-      mkdirp(opt.outputPath, function(err) {
-        if (err) {
-          return console.error(chalk.red('Error creating folder', opt.outputPath));
+    function(callback) {
+      var _this = this;
+      parseKssMarkup(filesBuffer, opt.kssOpt, function(styleguide) {
+        // If settings file is found, generate settings object
+        if (settingsStr) {
+          styleguide.settings = parseSettings(settingsStr);
         }
-      });
 
-      // Read and parse the overview markdown file
-      // TODO check async execution order
-      if (opt.overviewPath) {
-        fs.readFile(opt.overviewPath, function(err, file) {
-          if (err) {
-            console.error(chalk.red('Error reading file at ' + opt.overviewPath));
-            throw err;
-          }
-          // Define custom renderers for markup blocks
-          renderer.heading = function(text, level) {
-            return '<h' + level + ' class="sg">' + text + '</h' + level + '>';
-          }
-          renderer.paragraph = function(text) {
-            return '<p class="sg">' + text + '</p>';
-          }
-          renderer.listitem = function(text) {
-            return '<li class="sg">' + text + '</li>\n';
-          }
+        // Create JSON containing KSS data
+        _this.push(new File({
+          path: 'styleguide.json',
+          contents: new Buffer(JSON.stringify(styleguide))
+        }));
 
-          function escape(html, encode) {
-            return html
-              .replace(!encode ? /&(?!#?\w+;)/g : /&/g, '&amp;')
-              .replace(/</g, '&lt;')
-              .replace(/>/g, '&gt;')
-              .replace(/"/g, '&quot;')
-              .replace(/'/g, '&#39;');
-          }
-
-          renderer.code = function(code, lang, escaped) {
-            if (this.options.highlight) {
-              var out = this.options.highlight(code, lang);
-              if (out != null && out !== code) {
-                escaped = true;
-                code = out;
-              }
-            }
-
-            if (!lang) {
-              return '<pre class="sg"><code>'
-                + (escaped ? code : escape(code, true))
-                + '\n</code></pre>';
-            }
-
-            return '<pre class="sg"><code class="'
-              + this.options.langPrefix
-              + escape(lang, true)
-              + '">'
-              + (escaped ? code : escape(code, true))
-              + '\n</code></pre>\n';
-          }
-
-          fs.writeFile(opt.outputPath + '/overview.html', marked(String(file), {renderer: renderer}), function(err, buff) {
-            if (err) {
-              console.error(chalk.red('Error writing file to ' + opt.outputPath + '/overview.html'));
-              throw err;
-            }
-          });
-        });
-      }
-
-      preprocess(Object.keys(filesBuffer), opt, function() {
-        // Write generated styleguide JSON to disk
-        fs.writeFile(opt.outputPath + '/styleguide.json', JSON.stringify(styleguide),
-          function(err, buff) {
-            if (err) {
-              return console.error('Error writing styleguide.json', err);
-            }
-            // We're all done!
-            ncp(__dirname + '/dist', opt.outputPath, function(err) {
-              if (err) {
-                return console.error('Error creating styleguide directory', err);
-              }
-              console.log('Styleguide created to', opt.outputPath);
-
-              // Inject extraHead into HTML
-              if (opt.extraHead) {
-                fs.readFile(opt.outputPath + '/' + 'index.html', {encoding: 'utf8'}, function(err, data) {
-                  var formattedData = data.replace(/<!-- extraHead -->/, opt.extraHead.join('\n'));
-                  fs.writeFile(opt.outputPath + '/' + 'index.html', formattedData, function(err) {
-                    if (err) {
-                      throw err;
-                    }
-                    cb();
-                  });
-                });
-              } else {
+        // Process markdown file
+        if (opt.overviewPath) {
+          getMarkdownStream(opt.overviewPath)
+            .pipe(
+              through.obj(function(file, enc, cb) {
+                _this.push(file);
                 cb();
+              }).on('finish', function() {
+                checkIfDone(callback);
+              })
+            )
+        }
+
+        // Preprocess all CSS files and combile then to a single file
+        getPreprocessStream(Object.keys(filesBuffer), opt)
+          .pipe(
+            through.obj(function(file, enc, cb) {
+              _this.push(file);
+              cb();
+            }).on('finish', function() {
+              checkIfDone(callback);
+            })
+          );
+
+        // Copy all files from dist from to output stream
+        gulp.src(distPath + '/**')
+          .pipe(
+            through.obj(function(file, enc, cb) {
+              // Inject extra markup to index.html
+              if (file.path.indexOf(distPath + '/index.html') > -1) {
+                file.contents = new Buffer(injectContent(file.contents.toString(), opt));
               }
-            });
-          });
+              _this.push(file);
+              cb();
+            }).on('finish', function() {
+              checkIfDone(callback);
+            })
+          );
       });
-    });
+    }
+  );
 };
 
 /* Utility functions */
 
-function sanitize(string) {
-  string = sanitizeHtml(string, {allowedTags: [], allowedAttributes: []})
+function getMarkdownStream(filePath) {
+  var renderer = {};
+  // Define custom renderers for markup blocks
+  renderer.heading = function(text, level) {
+    return '<h' + level + ' class="sg">' + text + '</h' + level + '>';
+  }
+  renderer.paragraph = function(text) {
+    return '<p class="sg">' + text + '</p>';
+  }
+  renderer.listitem = function(text) {
+    return '<li class="sg">' + text + '</li>\n';
+  }
 
-  return string;
+  renderer.code = function(code, lang, escaped) {
+    var htmlEscape = function(html, encode) {
+      return html
+        .replace(!encode ? /&(?!#?\w+;)/g : /&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+    }
+
+    if (this.options.highlight) {
+      var out = this.options.highlight(code, lang);
+      if (out != null && out !== code) {
+        escaped = true;
+        code = out;
+      }
+    }
+
+    if (!lang) {
+      return '<pre class="sg"><code>'
+        + (escaped ? code : htmlEscape(code, true))
+        + '\n</code></pre>';
+    }
+
+    return '<pre class="sg"><code class="'
+      + this.options.langPrefix
+      + htmlEscape(lang, true)
+      + '">'
+      + (escaped ? code : htmlEscape(code, true))
+      + '\n</code></pre>\n';
+  }
+  return vfs.src(filePath)
+    .pipe(marked({renderer: renderer}))
 }
 
-// Processes all SASS/LESS/CSS files, concats them and places file to outputPath
-function preprocess(files, opt, callback) {
+function injectContent(data, opt) {
+  if (opt.extraHead) {
+    return data.replace(/<!-- extraHead -->/, opt.extraHead.join('\n'));
+  }
+  return data;
+}
 
+function sanitize(string) {
+  return sanitizeHtml(string, {allowedTags: [], allowedAttributes: []});
+}
+
+// Processes all SASS/LESS/CSS files and combine to a single file
+function getPreprocessStream(files, opt) {
   opt.sass.quiet = true; // Supress gulp-ruby-sass messages
   var sassStream,
     lessStream,
@@ -207,22 +219,11 @@ function preprocess(files, opt, callback) {
     .pipe(concat('css.css'));
 
   return es.merge(sassStream, lessStream, cssStream)
-    .pipe(concat('styleguide.css'))
-    .pipe(vfs.dest(opt.outputPath))
-    .pipe(through2(
-      {
-        objectMode: true,
-        allowHalfOpen: false
-      }, function(file, enc, cb) {
-        cb()
-      }, function(cb) {
-        callback();
-        cb();
-      }));
+    .pipe(concat('styleguide.css'));
 }
 
 // Parse node-kss object ( {'file.path': 'file.contents.toString('utf8'}' )
-function jsonStyleGuide(files, options) {
+function parseKssMarkup(files, options, success) {
   var json = {};
 
   kss.parse(files, options, function(err, styleguide) {
@@ -231,10 +232,11 @@ function jsonStyleGuide(files, options) {
       return false;
     } else {
       json.sections = jsonSections(styleguide.section());
+      if (typeof success === 'function') {
+        success(json);
+      }
     }
   });
-
-  return json;
 }
 
 // Parses kss.KssSection to JSON
@@ -274,6 +276,5 @@ function parseSettings(string) {
     a = match[1].match(/(.*)\:(.*)/);
     out[a[1]] = a[2].trim();
   }
-
   return out;
 }

--- a/package.json
+++ b/package.json
@@ -31,9 +31,10 @@
     "gulp-sass": "^0.7.3",
     "gulp-util": "^3.0.1",
     "gulp-bower": "^0.0.6",
+    "gulp-marked": "^1.0.0",
+    "stream-assert-gulp": "^0.4.3",
     "jade": "^1.6.0",
     "kss": "^1.0.0",
-    "marked": "^0.3.2",
     "mkdirp": "^0.5.0",
     "morgan": "^1.3.0",
     "ncp": "^0.6.0",
@@ -43,7 +44,8 @@
     "serve-favicon": "^2.1.3",
     "socket.io": "^1.1.0",
     "through2": "^0.6.1",
-    "vinyl-fs": "^0.3.7"
+    "vinyl-fs": "^0.3.7",
+    "vinyl": "^0.4.3"
   },
   "devDependencies": {
     "gulp-flatten": "0.0.2",
@@ -51,7 +53,6 @@
     "gulp-plumber": "^0.6.5",
     "gulp-sourcemaps": "^1.2.2",
     "chai": "^1.9.2",
-    "chai-fs": "^0.1.0",
     "exec-sync": "^0.1.6",
     "gulp-jscs": "^1.1.2",
     "gulp-jshint": "^1.8.4",
@@ -62,6 +63,7 @@
     "main-bower-files": "^2.0.0"
   },
   "scripts": {
-    "prepublish": "node node_modules/gulp/bin/gulp.js build"
+    "test": "node_modules/mocha/bin/mocha && node_modules/gulp/bin/gulp.js jscs",
+    "prepublish": "node_modules/gulp/bin/gulp.js build"
   }
 }

--- a/test/structure.js
+++ b/test/structure.js
@@ -3,6 +3,7 @@ var gulp = require('gulp'),
   runSequence = require('run-sequence'),
   execSync = require('exec-sync'),
   styleguide = require('../lib/styleguide.js'),
+  through = require('through2'),
   data = {
     source: {
       css: ['./demo/source/**/*.scss'],
@@ -11,15 +12,10 @@ var gulp = require('gulp'),
     output: './test/demo/output'
   };
 
-chai.use(require('chai-fs'));
-
 chai.config.includeStack = true;
+chai.should();
 
-global.expect = chai.expect;
-global.AssertionError = chai.AssertionError;
-global.Assertion = chai.Assertion;
-global.assert = chai.assert;
-gulp.task('testStyleguide', function(done, cb) {
+function styleguideStream() {
   return gulp.src(data.source.css)
     .pipe(styleguide({
       outputPath: data.output,
@@ -32,18 +28,51 @@ gulp.task('testStyleguide', function(done, cb) {
         // Options passed to gulp-ruby-sass
       }
     }))
-});
+}
 
-describe('structure', function() {
-  before(function() {
-    // clean up
-    execSync('rm -r ' + data.output);
+// This collector collects all files from the stream to the array passed as parameter
+function collector(collection) {
+  return function(file, enc, cb) {
+    if (!file.path) {
+      return;
+    }
+    collection.push(file);
+    cb();
+  };
+}
+
+function findFile(files, name) {
+  for (var i = files.length - 1; i >= 0; i--) {
+    if (files[i].relative === name) {
+      return files[i];
+    }
+  };
+  return;
+}
+
+describe('index.html', function() {
+  var indexHtml;
+  this.timeout(5000);
+
+  before(function(done) {
+    var files = [];
+    styleguideStream().pipe(
+      through.obj({objectMode: true}, collector(files), function(callback) {
+        indexHtml = findFile(files, 'index.html');
+        done();
+      })
+    );
   });
 
-  it('test', function(done) {
-    runSequence('testStyleguide', function() {
-      assert.pathExists(data.output, 'The output was built');
-      done();
-    });
+  it('should exists', function() {
+    indexHtml.should.be.an('object');
+  });
+
+  it('should contain CSS style passed as parameter', function() {
+    indexHtml.contents.toString().should.contain('<link rel="stylesheet" type="text/css" href="your/custom/style.css">');
+  });
+
+  it('should contain JS file passed as parameter', function() {
+    indexHtml.contents.toString().should.contain('<script src="your/custom/script.js"></script>');
   });
 })


### PR DESCRIPTION
Refactor lib not to write anything to disk. This improves performance and testability.
This will introduce breaking changes in next version if you use it as gulp module. The output should be written using gulp.dest instead of using styleguide parameter.
