### PR TITLE
Remove unused stream-assert-gulp

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "sanitize-html": "^1.3.0",
     "serve-favicon": "^2.1.3",
     "socket.io": "^1.1.0",
-    "stream-assert-gulp": "^0.4.3",
     "through2": "^0.6.1",
     "vinyl": "^0.4.3",
     "vinyl-fs": "^0.3.7",


### PR DESCRIPTION
Depcheck gives this output:

```
❯ depcheck
Unused Dependencies
* debug
* gulp-ruby-sass
* jade
* node-bourbon
* stream-assert-gulp
* yargs

Unused devDependencies
* gulp-flatten
* gulp-jshint
* jscs
* karma
* karma-chai
* karma-mocha
* karma-phantomjs-launcher
* mocha
* sinon
* tiny-lr
```

Some of them can be also removed.
