### PR TITLE
Add commonClass option that is added to every preview block

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,10 @@ These HTML elements are injected inside the styleguide head-tag.
 
 Options passed to gulp-ruby-sass
 
+**commonClass** (array or string, optional)
+
+This class is added to all preview blocks in the generated styleguide. If your styles have some namespace class that needs to be added to every block and you do not want to add it to every example you can use commonClass option.
+
 **appRoot** (string, optional)
 
 Define `appRoot` parameter if you host styleguide in other than root folder of the HTTP serve. If

--- a/bin/styleguide
+++ b/bin/styleguide
@@ -9,6 +9,7 @@ var styleguide = require(__dirname + '/../lib/styleguide.js'),
   yargs = require('yargs'),
   neat = require('node-neat'),
   util = require('gulp-util'),
+  extend = require('node.extend'),
   argv,
   gulpProcess,
   config,
@@ -42,19 +43,17 @@ config = configPath ? require(configPath) : {};
 
 gulp.task('styleguide', function() {
   // Resolve overviewPath in relation to config file location
-  var overviewPath;
   if (config.overviewPath) {
-    overviewPath = path.resolve(path.dirname(argv.config), config.overviewPath);
+    config.overviewPath = path.resolve(path.dirname(argv.config), config.overviewPath);
   }
+  var defaultConfig = {
+    socketIo: !!argv.server,
+    sass: {
+      loadPath: neat.includePaths
+    }
+  };
   gulp.src(sourceFiles)
-    .pipe(styleguide({
-      extraHead: config.extraHead,
-      overviewPath: overviewPath,
-      socketIo: !!argv.server,
-      sass: {
-        loadPath: neat.includePaths
-      }
-    }))
+    .pipe(styleguide(extend(defaultConfig, config)))
     .pipe(gulp.dest(outputPath));
 });
 

--- a/demo/source/styleguide_config.json
+++ b/demo/source/styleguide_config.json
@@ -1,4 +1,5 @@
 {
   "title": "Demo Styleguide",
-  "overviewPath": "overview.md"
+  "overviewPath": "overview.md",
+  "commonClass": ["custom-class-1", "custom-class-2"]
 }

--- a/lib/app/js/controllers/sections.js
+++ b/lib/app/js/controllers/sections.js
@@ -35,4 +35,7 @@ angular.module('sgApp')
       return re.test(section.reference);
     }
 
+    $scope.getCommonClass = function() {
+      return $rootScope.config.commonClass;
+    }
   });

--- a/lib/app/js/directives/dynamicCompile.js
+++ b/lib/app/js/directives/dynamicCompile.js
@@ -7,7 +7,7 @@ angular.module('sgApp')
         var parsed = $parse(iAttrs.ngBindHtml);
         function getStringValue() { return (parsed($scope) || '').toString(); }
 
-        //Recompile if the template changes
+        // Recompile if the template changes
         $scope.$watch(getStringValue, function() {
           $compile(iElm, null, 0)($scope);
         });

--- a/lib/app/views/partials/section.html
+++ b/lib/app/views/partials/section.html
@@ -31,6 +31,8 @@
       </div>
     </div>
     <div
+      class="markup"
+      ng-class="getCommonClass()"
       ng-if="!section.modifiers.length && section.markup"
       class="markup">
       <a ng-href="{{section.reference}}/fullscreen" target="_blank">

--- a/lib/styleguide.js
+++ b/lib/styleguide.js
@@ -36,12 +36,13 @@ module.exports = function(opt) {
     outputPath: opt.outputPath,
     sass: opt.sass || {},
     overviewPath: opt.overviewPath || __dirname + '/overview.md',
-    extraHead: opt.extraHead || [],
+    extraHead: opt.extraHead || '',
     appRoot: opt.appRoot || '',
+    commonClass: opt.commonClass || '',
     socketIo: opt.socketIo
   };
 
-  if (typeof opt.extraHead == 'object') opt.extraHead.join('\n');
+  if (typeof opt.extraHead === 'object') opt.extraHead = opt.extraHead.join('\n');
   if (!opt.kssOpt) opt.kssOpt = {};
 
   // Files object acts as our buffer

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "ncp": "^0.6.0",
     "node-bourbon": "^1.2.3",
     "node-neat": "^1.3.0",
+    "node.extend": "^1.1.2",
     "run-sequence": "^1.0.1",
     "sanitize-html": "^1.3.0",
     "serve-favicon": "^2.1.3",

--- a/test/angular/controllers/mainCtrl.js
+++ b/test/angular/controllers/mainCtrl.js
@@ -21,7 +21,11 @@ describe('Controller: MainCtrl', function() {
       $scope: scope
     });
 
-    json = {sections:[{heading: 'Title'}, {heading: 'Title2'}]};
+    json = {
+      sections:[
+        {heading: 'Title'}, {heading: 'Title2'}
+      ]
+    };
 
     httpBackend.expectGET('styleguide.json').
       respond(json);

--- a/test/project/source/styleguide_config.json
+++ b/test/project/source/styleguide_config.json
@@ -2,5 +2,6 @@
   "extraHead": [
     "<!-- extraHead comment -->"
   ],
-  "overviewPath": "overview.md"
+  "overviewPath": "overview.md",
+  "commonClass": ["custom-class-1", "custom-class-2"]
 }

--- a/test/structure.js
+++ b/test/structure.js
@@ -5,32 +5,27 @@ var gulp = require('gulp'),
   execSync = require('exec-sync'),
   styleguide = require('../lib/styleguide.js'),
   through = require('through2'),
-  data = {
-    source: {
-      css: ['./test/project/source/**/*.scss'],
-      overview: './test/project/source/overview.md'
-    },
-    output: './test/project/output'
+  defaultSource = './test/project/source/**/*.scss',
+  defaultConfig = {
+    title: 'Test Styleguide',
+    overviewPath: './test/project/source/overview.md',
+    appRoot: '/my-styleguide-book',
+    extraHead: [
+      '<link rel="stylesheet" type="text/css" href="your/custom/style.css">',
+      '<script src="your/custom/script.js"></script>'
+    ],
+    commonClass: ['custom-class-1', 'custom-class-2'],
+    sass: {
+      // Options passed to gulp-ruby-sass
+    }
   };
 
 chai.config.includeStack = true;
 var should = chai.should();
 
 function styleguideStream() {
-  return gulp.src(data.source.css)
-    .pipe(styleguide({
-      title: 'Test Styleguide',
-      outputPath: data.output,
-      overviewPath: data.source.overview,
-      appRoot: '/my-styleguide-book',
-      extraHead: [
-        '<link rel="stylesheet" type="text/css" href="your/custom/style.css">',
-        '<script src="your/custom/script.js"></script>'
-      ],
-      sass: {
-        // Options passed to gulp-ruby-sass
-      }
-    }))
+  return gulp.src(defaultSource)
+    .pipe(styleguide(defaultConfig))
 }
 
 // This collector collects all files from the stream to the array passed as parameter
@@ -152,6 +147,14 @@ describe('styleguide.json', function() {
 
   it('should contain correct appRoot', function() {
     jsonData.config.appRoot.should.eql('/my-styleguide-book');
+  });
+
+  it('should contain extra heads in correct format', function() {
+    jsonData.config.extraHead.should.eql(defaultConfig.extraHead[0] + '\n' + defaultConfig.extraHead[1]);
+  });
+
+  it('should contain all common classes', function() {
+    jsonData.config.commonClass.should.eql(['custom-class-1', 'custom-class-2']);
   });
 
   it('should not reveal outputPath', function() {


### PR DESCRIPTION
This class is added to all preview blocks in the generated styleguide. If your styles have some namespace class that needs to be added to every block and you do not want to add it to every example you can use commonClass option.

Contains also minor bug fix:
- extraHead parameter added extra common to generated HTML markup when passing array
