### PR TITLE
Fixed double inclusion of Angular dependencies

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -70,10 +70,15 @@ gulp.task('styleguide', function() {
 });
 
 gulp.task('js:app', function() {
-  return gulp.src(['lib/app/js/**/*.js', '!lib/app/js/vendor/**/*.js'])
-    .pipe(plumber())
-    .pipe(concat('app.js'))
-    .pipe(gulp.dest(distPath + '/js'));
+  return gulp.src([
+    'lib/app/js/app.js',
+    'lib/app/js/controllers/*.js',
+    'lib/app/js/directives/*.js',
+    'lib/app/js/services/*.js'
+  ])
+  .pipe(plumber())
+  .pipe(concat('app.js'))
+  .pipe(gulp.dest(distPath + '/js'));
 });
 
 gulp.task('js:vendor', ['bower'], function() {


### PR DESCRIPTION
Angular was loading dependencies twice from app.js and vendor.js which caused warnings and errors in application. Modified gulpfile now concats app files explicitly. 
