### PR TITLE
fixes failed styleguide generation when section modifier has no markup

### DIFF
--- a/lib/modules/wrapper-markup.js
+++ b/lib/modules/wrapper-markup.js
@@ -62,7 +62,6 @@ module.exports.generateSectionWrapperMarkup = function(sections) {
       wrapper = parentWrapper.replace('<sg:wrapper-content/>', wrapper);
     }
     section.wrapper = wrapper;
-
     if (section.markup) {
       /* Clean markup */
       if (section.markup.indexOf('<sg:wrapper>') !== -1) {
@@ -76,7 +75,7 @@ module.exports.generateSectionWrapperMarkup = function(sections) {
     /* Wrap modifiers */
     section.modifiers.forEach(function(modifier) {
       /* Clean modifier markup */
-      if (modifier.markup.indexOf('<sg:wrapper>') !== -1) {
+      if (modifier.markup && modifier.markup.indexOf('<sg:wrapper>') !== -1) {
         modifier.markup = modifier.markup.substring(0, modifier.markup.indexOf('<sg:wrapper'));
       }
       /* Wrap modifier markup */


### PR DESCRIPTION
If a section had modifiers without markup like:

```
// The standard call to action button
//
// :hover             - Subtle hover highlight.
// :active            - Active state of the button
// .disabled          - Dims the button to indicate it cannot be used.
// [disabled]         - Dims the button to indicate it cannot be used.
// .icon-only         - Hides text of button
//
// Styleguide 2.0
```

The styleguide generation failed with:
TypeError: Cannot call method 'indexOf' of null
