### PR TITLE
Improve npm package integration tests, fix missing CLI arguments

### DIFF
--- a/lib/modules/cli/argv.js
+++ b/lib/modules/cli/argv.js
@@ -16,6 +16,7 @@ module.exports = function(argLib) {
     .describe('appRoot', 'Define the appRoot parameter if you are hosting the style guide from a directory other than the root directory of the HTTP server')
     .describe('styleVariables', 'Specify the files to parse variable definitions from (defaults to all files/glob pattern passed to kssSource')
     .describe('server', 'Enable built-in web-server. To enable Desiger tool the style guide must be served with the built-in web server')
+    .describe('overviewPath', 'Overview file used as the generated style guide starting page. Parsed as Markdown.')
     .describe('port', 'Port of the server. Default is 3000')
     .describe('watch', 'Automatically generate styleguide on file change');
 };

--- a/lib/modules/cli/styleguide-cli.js
+++ b/lib/modules/cli/styleguide-cli.js
@@ -4,43 +4,55 @@ var path = require('path'),
 
 module.exports = function(argv) {
 
-  var styleguide = require(path.resolve(__dirname, '../../styleguide'));
-
-  gulp.task('styleguide:generate', function() {
-    return gulp.src(argv.kssSource)
-      .pipe(styleguide.generate({
-        title: argv.title,
-        rootPath: argv.output,
-        extraHead: argv.extraHead,
-        commonClass: argv.commonClass,
-        appRoot: argv.appRoot,
-        styleVariables: argv.styleVariables,
-        server: argv.server,
-        port: argv.port
-      }))
-      .pipe(gulp.dest(argv.output));
-  });
-
-  gulp.task('styleguide:applystyles', function() {
-    return gulp.src(argv.styleSource)
-      .pipe(styleguide.applyStyles())
-      .pipe(gulp.dest(argv.output));
-  });
-
-  gulp.task('watch:kss', function() {
-    return gulp.watch(argv.kssSource, ['styleguide:generate']);
-  });
-
-  gulp.task('watch:styles', function() {
-    return gulp.watch(argv.styleSource, ['styleguide:applystyles']);
-  });
-
-  var tasks = ['styleguide:generate', 'styleguide:applystyles'];
-  if (argv.watch) {
-    tasks.push('watch:styles');
-    tasks.push('watch:kss');
+  function logError(err) {
+    console.error(err);
   }
 
-  runSequence.apply(this, tasks);
+  try {
+
+    var styleguide = require(path.resolve(__dirname, '../../styleguide'));
+
+    gulp.task('styleguide:generate', function() {
+      console.log('Generating style guide to output dir:', argv.output);
+      return gulp.src(argv.kssSource)
+        .pipe(styleguide.generate({
+          title: argv.title,
+          rootPath: argv.output,
+          extraHead: argv.extraHead,
+          commonClass: argv.commonClass,
+          appRoot: argv.appRoot,
+          styleVariables: argv.styleVariables,
+          server: argv.server,
+          port: argv.port
+        }).on('error', logError))
+        .pipe(gulp.dest(argv.output));
+    });
+
+    gulp.task('styleguide:applystyles', function() {
+      return gulp.src(argv.styleSource)
+        .pipe(styleguide.applyStyles().on('error', logError))
+        .pipe(gulp.dest(argv.output));
+    });
+
+    gulp.task('watch:kss', function() {
+      return gulp.watch(argv.kssSource, ['styleguide:generate']);
+    });
+
+    gulp.task('watch:styles', function() {
+      return gulp.watch(argv.styleSource, ['styleguide:applystyles']);
+    });
+
+    var tasks = ['styleguide:generate', 'styleguide:applystyles'];
+    if (argv.watch) {
+      tasks.push('watch:styles');
+      tasks.push('watch:kss');
+    }
+
+    runSequence.apply(this, tasks);
+
+  } catch (err) {
+    console.error('Style guide generation failed');
+    logError(err);
+  }
 
 };

--- a/lib/modules/cli/styleguide-cli.js
+++ b/lib/modules/cli/styleguide-cli.js
@@ -22,6 +22,7 @@ module.exports = function(argv) {
           commonClass: argv.commonClass,
           appRoot: argv.appRoot,
           styleVariables: argv.styleVariables,
+          overviewPath: argv.overviewPath,
           server: argv.server,
           port: argv.port
         }).on('error', logError))

--- a/test/integration/assert-at-rules.js
+++ b/test/integration/assert-at-rules.js
@@ -13,9 +13,8 @@ module.exports = (function() {
         expect(file).to.be.an('object');
       });
 
-      it('should contain pseudo classes converted to normal class names', function() {
-        expect(file.contents.toString()).to.contain('.test-style.pseudo-class-hover {');
-        expect(file.contents.toString()).to.contain('.test-style.pseudo-class-active {');
+      it('should contain at rules', function() {
+        expect(file.contents.toString()).to.contain('@keyframes myanimation {');
       });
 
       it('should not contain content from sourcemaps file', function() {

--- a/test/integration/assert-index-html.js
+++ b/test/integration/assert-index-html.js
@@ -1,0 +1,34 @@
+var expect = require('chai').expect;
+
+module.exports = (function() {
+
+  var indexHtml;
+
+  return {
+    set: function(file) {
+      indexHtml = file;
+    },
+    register: function() {
+      it('should exist', function() {
+        expect(indexHtml).to.be.an('object');
+      });
+
+      it('should contain correct title', function() {
+        expect(indexHtml.contents.toString()).to.contain('>Test Styleguide</title>');
+      });
+
+      it('should contain CSS style passed as parameter', function() {
+        expect(indexHtml.contents.toString()).to.contain('<link rel="stylesheet" type="text/css" href="your/custom/style.css">');
+      });
+
+      it('should contain JS file passed as parameter', function() {
+        expect(indexHtml.contents.toString()).to.contain('<script src="your/custom/script.js"></script>');
+      });
+
+      it('should define application root', function() {
+        expect(indexHtml.contents.toString()).to.contain('<base href="/my-styleguide-book/" />');
+      });
+    }
+  };
+
+}());

--- a/test/integration/assert-index-html.js
+++ b/test/integration/assert-index-html.js
@@ -2,31 +2,31 @@ var expect = require('chai').expect;
 
 module.exports = (function() {
 
-  var indexHtml;
+  var file;
 
   return {
-    set: function(file) {
-      indexHtml = file;
+    set: function(fileObj) {
+      file = fileObj;
     },
     register: function() {
       it('should exist', function() {
-        expect(indexHtml).to.be.an('object');
+        expect(file).to.be.an('object');
       });
 
       it('should contain correct title', function() {
-        expect(indexHtml.contents.toString()).to.contain('>Test Styleguide</title>');
+        expect(file.contents.toString()).to.contain('>Test Styleguide</title>');
       });
 
       it('should contain CSS style passed as parameter', function() {
-        expect(indexHtml.contents.toString()).to.contain('<link rel="stylesheet" type="text/css" href="your/custom/style.css">');
+        expect(file.contents.toString()).to.contain('<link rel="stylesheet" type="text/css" href="your/custom/style.css">');
       });
 
       it('should contain JS file passed as parameter', function() {
-        expect(indexHtml.contents.toString()).to.contain('<script src="your/custom/script.js"></script>');
+        expect(file.contents.toString()).to.contain('<script src="your/custom/script.js"></script>');
       });
 
       it('should define application root', function() {
-        expect(indexHtml.contents.toString()).to.contain('<base href="/my-styleguide-book/" />');
+        expect(file.contents.toString()).to.contain('<base href="/my-styleguide-book/" />');
       });
     }
   };

--- a/test/integration/assert-overview-html.js
+++ b/test/integration/assert-overview-html.js
@@ -1,0 +1,35 @@
+var expect = require('chai').expect;
+
+module.exports = (function() {
+
+  var file;
+
+  return {
+    set: function(fileObj) {
+      file = fileObj;
+    },
+    register: function() {
+      it('should exist', function() {
+        expect(file).to.be.an('object');
+      });
+
+      it('should have valid headers with sg class', function() {
+        expect(file.contents.toString()).to.contain('<h1 class="sg heading">Title1</h1>');
+        expect(file.contents.toString()).to.contain('<h2 class="sg heading">Title2</h2>');
+      });
+
+      it('should have valid paragraph with sg class', function() {
+        expect(file.contents.toString()).to.contain('<p class="sg">Ut turkish, wings, sit to go barista half');
+      });
+
+      it('should escape code snippets and add sg class', function() {
+        expect(file.contents.toString()).to.contain('<pre class="sg"><code>&lt;div class=&quot;foobar&gt;Test code snippet&lt;/div&gt;\n</code></pre>');
+      });
+
+      it('should have valid links with sg class', function() {
+        expect(file.contents.toString()).to.contain('<a class="sg" href="http://example.com">Example link</a>');
+      });
+    }
+  };
+
+}());

--- a/test/integration/assert-pseudo-styles.js
+++ b/test/integration/assert-pseudo-styles.js
@@ -1,0 +1,27 @@
+var expect = require('chai').expect;
+
+module.exports = (function() {
+
+  var styleguideFile;
+
+  return {
+    set: function(file) {
+      styleguideFile = file;
+    },
+    register: function() {
+      it('should exist', function() {
+        expect(styleguideFile).to.be.an('object');
+      });
+
+      it('should contain pseudo classes converted to normal class names', function() {
+        expect(styleguideFile.contents.toString()).to.contain('.test-style.pseudo-class-hover {');
+        expect(styleguideFile.contents.toString()).to.contain('.test-style.pseudo-class-active {');
+      });
+
+      it('should not contain content from sourcemaps file', function() {
+        expect(styleguideFile.contents.toString()).not.to.contain('{{test.map content}}');
+      });
+    }
+  };
+
+}());

--- a/test/integration/assert-styleguide-css.js
+++ b/test/integration/assert-styleguide-css.js
@@ -1,0 +1,23 @@
+var expect = require('chai').expect;
+
+module.exports = (function() {
+
+  var file;
+
+  return {
+    set: function(fileObj) {
+      file = fileObj;
+    },
+    register: function() {
+      it('should exist', function() {
+        expect(file).to.be.an('object');
+      });
+
+      it('should include css from the all specified sources', function() {
+        expect(file.contents.toString()).to.contain('.test-style {\n  position: absolute;');
+        expect(file.contents.toString()).to.contain('.test-style2 {\n  position: absolute;');
+      });
+    }
+  };
+
+}());

--- a/test/integration/assert-styleguide-json.js
+++ b/test/integration/assert-styleguide-json.js
@@ -1,0 +1,114 @@
+var path = require('path'),
+    expect = require('chai').expect,
+    config = require('./test-config');
+
+module.exports = (function() {
+
+  var json, variablesFile;
+
+  return {
+    setJson: function(obj) {
+      if (obj.contents) {
+        json = JSON.parse(obj.contents);
+      } else {
+        json = obj;
+      }
+    },
+    setVariablesFile: function(file) {
+      variablesFile = file;
+    },
+    register: function() {
+      it('should exist', function() {
+        expect(json).to.be.an('object');
+      });
+
+      it('should contain correct title', function() {
+        expect(json.config.title).to.eql('Test Styleguide');
+      });
+
+      it('should contain correct appRoot', function() {
+        expect(json.config.appRoot).to.eql('/my-styleguide-book');
+      });
+
+      it('should contain extra heads in correct format', function() {
+        expect(json.config.extraHead).to.eql(config.extraHead[0] + '\n' + config.extraHead[1]);
+      });
+
+      it('should contain all common classes', function() {
+        expect(json.config.commonClass).to.eql(['custom-class-1', 'custom-class-2']);
+      });
+
+      it('should contain all style variable names from defined json', function() {
+        expect(json.variables[0].name).to.eql('color-red');
+        expect(json.variables[1].name).to.eql('color-green');
+        expect(json.variables[2].name).to.eql('color-blue');
+      });
+
+      it('should contain all style variable values from defined json', function() {
+        expect(json.variables[0].value).to.eql('#ff0000');
+        expect(json.variables[1].value).to.eql('#00ff00');
+        expect(json.variables[2].value).to.eql('#0000ff');
+      });
+
+      it('should not reveal outputPath', function() {
+        expect(json.config.outputPath).to.not.exist;
+      });
+
+      it('should have all the modifiers', function() {
+        expect(json.sections[1].modifiers.length).to.eql(4);
+      });
+
+      // Markup
+
+      it('should print markup if defined', function() {
+        expect(json.sections[0].markup).to.not.be.empty;
+      });
+
+      it('should not print empty markup', function() {
+        expect(json.sections[2].markup).to.not.exist;
+      });
+
+      // Related CSS
+
+      it('should not print empty CSS', function() {
+        expect(json.sections[1].css).to.not.exist;
+      });
+
+      it('should have section CSS', function() {
+        expect(json.sections[2].css).to.eql('.test-css {color: purple;}');
+      });
+
+      // Related variables
+
+      it('should contain all related variables', function() {
+        var relatedVariables = ['color-red', 'color-green', 'color-blue'];
+        expect(json.sections[3].variables).to.eql(relatedVariables);
+      });
+
+      it('should parse related variables also from modifiers', function() {
+        var relatedVariables = ['color-red', 'color-green', 'color-blue'];
+        expect(json.sections[1].variables).to.eql(relatedVariables);
+      });
+
+      it('should not add variables if section does not contain related variables', function() {
+        expect(json.sections[2].variables).to.eql([]);
+      });
+
+      it('should contain variable source file base names', function() {
+        var base = path.basename(variablesFile);
+        expect(json.variables[0].file).to.eql(base);
+        expect(json.variables[1].file).to.eql(base);
+        expect(json.variables[2].file).to.eql(base);
+      });
+
+      it('should contain hex-encoded hash of source file paths', function() {
+        var hex = /[a-h0-9]/;
+        expect(json.variables[0].fileHash).to.match(hex);
+        expect(json.variables[1].fileHash).to.match(hex);
+        expect(json.variables[2].fileHash).to.match(hex);
+      });
+
+    }
+  };
+
+}());

--- a/test/integration/assert-template.js
+++ b/test/integration/assert-template.js
@@ -1,0 +1,19 @@
+var expect = require('chai').expect;
+
+module.exports = (function() {
+
+  var file;
+
+  return {
+    set: function(fileObj) {
+      file = fileObj;
+    },
+    register: function() {
+      it('should exist', function() {
+        expect(file).to.be.an('object');
+      });
+
+    }
+  };
+
+}());

--- a/test/integration/assertions.js
+++ b/test/integration/assertions.js
@@ -1,0 +1,4 @@
+module.exports = {
+  indexHtml: require('./assert-index-html'),
+  pseudoStyles: require('./assert-pseudo-styles')
+};

--- a/test/integration/assertions.js
+++ b/test/integration/assertions.js
@@ -1,5 +1,6 @@
 module.exports = {
   indexHtml: require('./assert-index-html'),
+  overviewHtml: require('./assert-overview-html'),
   pseudoStyles: require('./assert-pseudo-styles'),
   atRules: require('./assert-at-rules')
 };

--- a/test/integration/assertions.js
+++ b/test/integration/assertions.js
@@ -3,5 +3,6 @@ module.exports = {
   overviewHtml: require('./assert-overview-html'),
   pseudoStyles: require('./assert-pseudo-styles'),
   atRules: require('./assert-at-rules'),
-  styleguideCss: require('./assert-styleguide-css')
+  styleguideCss: require('./assert-styleguide-css'),
+  styleguideJson: require('./assert-styleguide-json')
 };

--- a/test/integration/assertions.js
+++ b/test/integration/assertions.js
@@ -2,5 +2,6 @@ module.exports = {
   indexHtml: require('./assert-index-html'),
   overviewHtml: require('./assert-overview-html'),
   pseudoStyles: require('./assert-pseudo-styles'),
-  atRules: require('./assert-at-rules')
+  atRules: require('./assert-at-rules'),
+  styleguideCss: require('./assert-styleguide-css')
 };

--- a/test/integration/assertions.js
+++ b/test/integration/assertions.js
@@ -1,4 +1,5 @@
 module.exports = {
   indexHtml: require('./assert-index-html'),
-  pseudoStyles: require('./assert-pseudo-styles')
+  pseudoStyles: require('./assert-pseudo-styles'),
+  atRules: require('./assert-at-rules')
 };

--- a/test/integration/npm-package.test.js
+++ b/test/integration/npm-package.test.js
@@ -33,42 +33,30 @@ describe('npm package executable', function() {
   });
 
   describe('generated style guide from SCSS test project', function() {
-
     var output = path.join(testDir, 'scss-test-output');
-
     before(function(done) {
       this.timeout(30000);
       generateScssTestProjectStyleGuide(output).then(done).catch(done);
     });
-
     checkStructure(output);
-
   });
 
   describe('generated style guide from LESS test project', function() {
-
     var output = path.join(testDir, 'less-test-output');
-
     before(function(done) {
       this.timeout(30000);
       generateLessTestProjectStyleGuide(output).then(done).catch(done);
     });
-
     checkStructure(output);
-
   });
 
   describe('generated demo style guide', function() {
-
     var output = path.join(testDir, 'demo-test-output');
-
     before(function(done) {
       this.timeout(30000);
       generateDemoStyleGuide(output).then(done).catch(done);
     });
-
     checkStructure(output);
-
   });
 
 });
@@ -175,31 +163,22 @@ function spawn(cmd, args, opts) {
   });
 }
 
-function checkStructure(output) {
+function checkStructure(outputDir) {
+  addAssertion(outputDir, 'index.html', assertions.indexHtml);
+  addAssertion(outputDir, 'styleguide_pseudo_styles.css', assertions.pseudoStyles);
+  addAssertion(outputDir, 'styleguide_at_rules.css', assertions.atRules);
+}
 
-  describe('index.html', function() {
-
-    assertions.indexHtml.register();
-
-    before(function(done) {
-      var buffer = fs.readFileSync(path.join(output, 'index.html')),
-        file = { contents: buffer };
-      assertions.indexHtml.set(file);
-      done();
+function addAssertion(dir, fileName, assertion) {
+  describe(fileName, function() {
+    assertion.register();
+    before(function() {
+      assertion.set(getFile(dir, fileName));
     });
-
   });
+}
 
-  describe('styleguide_pseudo_styles.css', function() {
-
-    assertions.pseudoStyles.register();
-
-    before(function(done) {
-      var buffer = fs.readFileSync(path.join(output, 'styleguide_pseudo_styles.css')),
-        file = { contents: buffer };
-      assertions.pseudoStyles.set(file);
-      done();
-    });
-
-  });
+function getFile(dir, fileName) {
+  var buffer = fs.readFileSync(path.join(dir, fileName));
+  return { contents: buffer };
 }

--- a/test/integration/npm-package.test.js
+++ b/test/integration/npm-package.test.js
@@ -156,11 +156,6 @@ function deleteTempDir() {
 }
 
 function spawn(cmd, args, opts) {
-  var command = [cmd].concat(args).join(' ');
-
-  console.log('cwd:', opts.cwd);
-  console.log('Executing command:', command);
-
   return Q.promise(function(resolve, reject) {
     var error = '',
       proc = childProcess.spawn(cmd, args, opts),
@@ -175,6 +170,7 @@ function spawn(cmd, args, opts) {
       if (code === 0) {
         resolve();
       } else {
+        var command = [cmd].concat(args).join(' ');
         reject(new Error('Command exited with non-zero: ' + (code || signal) + '\n' + command + '\n' + error));
       }
     });

--- a/test/integration/npm-package.test.js
+++ b/test/integration/npm-package.test.js
@@ -165,6 +165,7 @@ function spawn(cmd, args, opts) {
 
 function checkStructure(outputDir) {
   addAssertion(outputDir, 'index.html', assertions.indexHtml);
+  addAssertion(outputDir, 'overview.html', assertions.overviewHtml);
   addAssertion(outputDir, 'styleguide_pseudo_styles.css', assertions.pseudoStyles);
   addAssertion(outputDir, 'styleguide_at_rules.css', assertions.atRules);
 }

--- a/test/integration/npm-package.test.js
+++ b/test/integration/npm-package.test.js
@@ -168,6 +168,7 @@ function checkStructure(outputDir) {
   addAssertion(outputDir, 'overview.html', assertions.overviewHtml);
   addAssertion(outputDir, 'styleguide_pseudo_styles.css', assertions.pseudoStyles);
   addAssertion(outputDir, 'styleguide_at_rules.css', assertions.atRules);
+  addAssertion(outputDir, 'styleguide.css', assertions.styleguideCss);
 }
 
 function addAssertion(dir, fileName, assertion) {

--- a/test/integration/npm-package.test.js
+++ b/test/integration/npm-package.test.js
@@ -99,19 +99,19 @@ function runNpmInstall() {
 
 function generateScssTestProjectStyleGuide(output) {
   var scssSrc = path.resolve(currentDir, '../projects/scss-project/source/**/*.scss'),
-      args = joinSharedConfig(['--kssSource', scssSrc,  '--output', output]);
+    args = joinSharedConfig(['--kssSource', scssSrc, '--output', output]);
   return generateStyleGuide(args);
 }
 
 function generateLessTestProjectStyleGuide(output) {
   var lessSrc = path.resolve(currentDir, '../projects/less-project/source/**/*.less'),
-      args = joinSharedConfig(['--kssSource', lessSrc, '--output', output]);
+    args = joinSharedConfig(['--kssSource', lessSrc, '--output', output]);
   return generateStyleGuide(args);
 }
 
 function generateDemoStyleGuide(output) {
   var src = path.resolve(npmSgDir, 'lib/app/**/*.scss'),
-      args = joinSharedConfig(['--kssSource', src, '--output', output]);
+    args = joinSharedConfig(['--kssSource', src, '--output', output]);
   return generateStyleGuide(args);
 }
 
@@ -183,11 +183,23 @@ function checkStructure(output) {
 
     before(function(done) {
       var buffer = fs.readFileSync(path.join(output, 'index.html')),
-        indexHtml = { contents: buffer };
-      assertions.indexHtml.set(indexHtml);
+        file = { contents: buffer };
+      assertions.indexHtml.set(file);
       done();
     });
 
   });
 
+  describe('styleguide_pseudo_styles.css', function() {
+
+    assertions.pseudoStyles.register();
+
+    before(function(done) {
+      var buffer = fs.readFileSync(path.join(output, 'styleguide_pseudo_styles.css')),
+        file = { contents: buffer };
+      assertions.pseudoStyles.set(file);
+      done();
+    });
+
+  });
 }

--- a/test/integration/structure.test.js
+++ b/test/integration/structure.test.js
@@ -73,8 +73,8 @@ describe('styleguide_pseudo_styles.css', function() {
     var files = [];
     styleguideApplyStylesStream().pipe(
       through.obj({objectMode: true}, collector(files), function(callback) {
-        var styleguideFile = findFile(files, 'styleguide_pseudo_styles.css');
-        assertions.pseudoStyles.set(styleguideFile);
+        var css = findFile(files, 'styleguide_pseudo_styles.css');
+        assertions.pseudoStyles.set(css);
         callback();
         done();
       })
@@ -92,8 +92,8 @@ describe('styleguide_at_rules.css', function() {
     var files = [];
     styleguideApplyStylesStream().pipe(
       through.obj({objectMode: true}, collector(files), function(callback) {
-        var styleguideFile = findFile(files, 'styleguide_at_rules.css');
-        assertions.atRules.set(styleguideFile);
+        var css = findFile(files, 'styleguide_at_rules.css');
+        assertions.atRules.set(css);
         callback();
         done();
       })
@@ -103,41 +103,22 @@ describe('styleguide_at_rules.css', function() {
 });
 
 describe('overview.html', function() {
-  var overviewHtml;
-  this.timeout(5000);
+
+  assertions.overviewHtml.register();
 
   before(function(done) {
+    this.timeout(5000);
     var files = [];
-
     styleguideGenerateStream().pipe(
       through.obj({objectMode: true}, collector(files), function(callback) {
-        overviewHtml = findFile(files, 'overview.html');
+        var overviewHtml = findFile(files, 'overview.html');
+        assertions.overviewHtml.set(overviewHtml);
         callback();
         done();
       })
     );
   });
 
-  it('should exist', function() {
-    expect(overviewHtml).to.be.an('object');
-  });
-
-  it('should have valid headers with sg class', function() {
-    expect(overviewHtml.contents.toString()).to.contain('<h1 class="sg heading">Title1</h1>');
-    expect(overviewHtml.contents.toString()).to.contain('<h2 class="sg heading">Title2</h2>');
-  });
-
-  it('should have valid paragraph with sg class', function() {
-    expect(overviewHtml.contents.toString()).to.contain('<p class="sg">Ut turkish, wings, sit to go barista half');
-  });
-
-  it('should escape code snippets and add sg class', function() {
-    expect(overviewHtml.contents.toString()).to.contain('<pre class="sg"><code>&lt;div class=&quot;foobar&gt;Test code snippet&lt;/div&gt;\n</code></pre>');
-  });
-
-  it('should have valid links with sg class', function() {
-    expect(overviewHtml.contents.toString()).to.contain('<a class="sg" href="http://example.com">Example link</a>');
-  });
 });
 
 function sharedStyleguideJSON() {

--- a/test/integration/structure.test.js
+++ b/test/integration/structure.test.js
@@ -65,7 +65,7 @@ describe('index.html', function() {
 });
 
 describe('styleguide_pseudo_styles.css', function() {
-  
+
   assertions.pseudoStyles.register();
 
   before(function(done) {

--- a/test/integration/structure.test.js
+++ b/test/integration/structure.test.js
@@ -2,7 +2,6 @@ var gulp = require('gulp'),
     chai = require('chai'),
     expect = chai.expect,
     through = require('through2'),
-    path = require('path'),
     styleguide = require('requirefrom')('lib')('styleguide'),
     assertions = require('./assertions'),
     defaultSource = 'test/projects/scss-project/source/**/*.scss',
@@ -139,95 +138,22 @@ describe('styleguide.css', function() {
 
 });
 
-function sharedStyleguideJSON() {
-  it('should exist', function() {
-    expect(this.jsonData).to.be.an('object');
-  });
-
-  it('should contain correct title', function() {
-    expect(this.jsonData.config.title).to.eql('Test Styleguide');
-  });
-
-  it('should contain correct appRoot', function() {
-    expect(this.jsonData.config.appRoot).to.eql('/my-styleguide-book');
-  });
-
-  it('should contain extra heads in correct format', function() {
-    expect(this.jsonData.config.extraHead).to.eql(defaultConfig.extraHead[0] + '\n' + defaultConfig.extraHead[1]);
-  });
-
-  it('should contain all common classes', function() {
-    expect(this.jsonData.config.commonClass).to.eql(['custom-class-1', 'custom-class-2']);
-  });
-
-  it('should contain all style variable names from defined file', function() {
-    expect(this.jsonData.variables[0].name).to.eql('color-red');
-    expect(this.jsonData.variables[1].name).to.eql('color-green');
-    expect(this.jsonData.variables[2].name).to.eql('color-blue');
-  });
-
-  it('should contain all style variable values from defined file', function() {
-    expect(this.jsonData.variables[0].value).to.eql('#ff0000');
-    expect(this.jsonData.variables[1].value).to.eql('#00ff00');
-    expect(this.jsonData.variables[2].value).to.eql('#0000ff');
-  });
-
-  it('should not reveal outputPath', function() {
-    expect(this.jsonData.config.outputPath).to.not.exist;
-  });
-
-  it('should have all the modifiers', function() {
-    expect(this.jsonData.sections[1].modifiers.length).to.eql(4);
-  });
-
-  // Markup
-
-  it('should print markup if defined', function() {
-    expect(this.jsonData.sections[0].markup).to.not.be.empty;
-  });
-
-  it('should not print empty markup', function() {
-    expect(this.jsonData.sections[2].markup).to.not.exist;
-  });
-
-  // Related CSS
-
-  it('should not print empty CSS', function() {
-    expect(this.jsonData.sections[1].css).to.not.exist;
-  });
-
-  it('should have section CSS', function() {
-    expect(this.jsonData.sections[2].css).to.eql('.test-css {color: purple;}');
-  });
-
-  // Related variables
-
-  it('should contain all related variables', function() {
-    var relatedVariables = ['color-red', 'color-green', 'color-blue'];
-    expect(this.jsonData.sections[3].variables).to.eql(relatedVariables);
-  });
-
-  it('should parse related variables also from modifiers', function() {
-    var relatedVariables = ['color-red', 'color-green', 'color-blue'];
-    expect(this.jsonData.sections[1].variables).to.eql(relatedVariables);
-  });
-
-  it('should not add variables if section does not contain related variables', function() {
-    expect(this.jsonData.sections[2].variables).to.eql([]);
-  });
-}
-
 describe('styleguide.json for SCSS project', function() {
 
   var source = 'test/projects/scss-project/source/**/*.scss',
       variablesFile = 'test/projects/scss-project/source/styles/_styleguide_variables.scss';
 
-  beforeEach(function(done) {
-    createStyleGuideJson(source, variablesFile, this, done);
+  assertions.styleguideJson.register();
+
+  before(function(done) {
+    var json = {};
+    createStyleGuideJson(source, variablesFile, json, function() {
+      assertions.styleguideJson.setJson(json.jsonData);
+      assertions.styleguideJson.setVariablesFile(variablesFile);
+      done();
+    });
   });
 
-  testVariablesFilePaths(variablesFile);
-  sharedStyleguideJSON();
 });
 
 describe('styleguide.json for LESS project', function() {
@@ -235,12 +161,17 @@ describe('styleguide.json for LESS project', function() {
   var source = 'test/projects/less-project/source/**/*.less',
       variablesFile = 'test/projects/less-project/source/styles/_styleguide_variables.less';
 
-  beforeEach(function(done) {
-    createStyleGuideJson(source, variablesFile, this, done);
+  assertions.styleguideJson.register();
+
+  before(function(done) {
+    var json = {};
+    createStyleGuideJson(source, variablesFile, json, function() {
+      assertions.styleguideJson.setJson(json.jsonData);
+      assertions.styleguideJson.setVariablesFile(variablesFile);
+      done();
+    });
   });
 
-  testVariablesFilePaths(variablesFile);
-  sharedStyleguideJSON();
 });
 
 function createStyleGuideJson(source, variablesFile, _this, done) {
@@ -255,22 +186,4 @@ function createStyleGuideJson(source, variablesFile, _this, done) {
       done();
     })
   );
-}
-
-function testVariablesFilePaths(variablesFile) {
-
-  it('should contain variable source file base names', function() {
-    var base = path.basename(variablesFile);
-    expect(this.jsonData.variables[0].file).to.eql(base);
-    expect(this.jsonData.variables[1].file).to.eql(base);
-    expect(this.jsonData.variables[2].file).to.eql(base);
-  });
-
-  it('should contain hex-encoded hash of source file paths', function() {
-    var hex = /[a-h0-9]/;
-    expect(this.jsonData.variables[0].fileHash).to.match(hex);
-    expect(this.jsonData.variables[1].fileHash).to.match(hex);
-    expect(this.jsonData.variables[2].fileHash).to.match(hex);
-  });
-
 }

--- a/test/integration/structure.test.js
+++ b/test/integration/structure.test.js
@@ -121,6 +121,24 @@ describe('overview.html', function() {
 
 });
 
+describe('styleguide.css', function() {
+
+  assertions.styleguideCss.register();
+
+  before(function(done) {
+    var files = [];
+    styleguideApplyStylesStream().pipe(
+      through.obj({objectMode: true}, collector(files), function(callback) {
+        var css = findFile(files, 'styleguide.css');
+        assertions.styleguideCss.set(css);
+        callback();
+        done();
+      })
+    );
+  });
+
+});
+
 function sharedStyleguideJSON() {
   it('should exist', function() {
     expect(this.jsonData).to.be.an('object');
@@ -198,30 +216,6 @@ function sharedStyleguideJSON() {
     expect(this.jsonData.sections[2].variables).to.eql([]);
   });
 }
-
-describe('styleguide.css', function() {
-  beforeEach(function(done) {
-    var files = [],
-      _this = this;
-
-    styleguideApplyStylesStream().pipe(
-      through.obj({objectMode: true}, collector(files), function(callback) {
-        _this.styleguideFile = findFile(files, 'styleguide.css');
-        callback();
-        done();
-      })
-    );
-  });
-
-  it('should exist', function() {
-    expect(this.styleguideFile).to.be.an('object');
-  });
-
-  it('should include css from the all specified sources', function() {
-    expect(this.styleguideFile.contents.toString()).to.contain('.test-style {\n  position: absolute;');
-    expect(this.styleguideFile.contents.toString()).to.contain('.test-style2 {\n  position: absolute;');
-  });
-});
 
 describe('styleguide.json for SCSS project', function() {
 

--- a/test/integration/structure.test.js
+++ b/test/integration/structure.test.js
@@ -4,19 +4,9 @@ var gulp = require('gulp'),
     through = require('through2'),
     path = require('path'),
     styleguide = require('requirefrom')('lib')('styleguide'),
+    assertions = require('./assertions'),
     defaultSource = 'test/projects/scss-project/source/**/*.scss',
-    defaultConfig = {
-      title: 'Test Styleguide',
-      overviewPath: 'test/projects/scss-project/source/test_overview.md',
-      appRoot: '/my-styleguide-book',
-      extraHead: [
-        '<link rel="stylesheet" type="text/css" href="your/custom/style.css">',
-        '<script src="your/custom/script.js"></script>'
-      ],
-      commonClass: ['custom-class-1', 'custom-class-2'],
-      styleVariables: 'test/projects/scss-project/source/styles/_styleguide_variables.scss',
-      filesConfig: []
-    };
+    defaultConfig = require('./test-config');
 
 chai.config.includeStack = true;
 
@@ -50,72 +40,47 @@ function findFile(files, name) {
 }
 
 describe('index.html', function() {
+
+  assertions.indexHtml.register();
+
   var indexHtml;
-  this.timeout(5000);
 
   before(function(done) {
+    this.timeout(5000);
     var files = [];
     styleguideGenerateStream().pipe(
       through.obj({objectMode: true}, collector(files), function(callback) {
         indexHtml = findFile(files, 'index.html');
+        assertions.indexHtml.set(indexHtml);
         callback();
         done();
       })
     );
-  });
-
-  it('should exist', function() {
-    expect(indexHtml).to.be.an('object');
-  });
-
-  it('should contain correct title', function() {
-    expect(indexHtml.contents.toString()).to.contain('>Test Styleguide</title>');
-  });
-
-  it('should contain CSS style passed as parameter', function() {
-    expect(indexHtml.contents.toString()).to.contain('<link rel="stylesheet" type="text/css" href="your/custom/style.css">');
-  });
-
-  it('should contain JS file passed as parameter', function() {
-    expect(indexHtml.contents.toString()).to.contain('<script src="your/custom/script.js"></script>');
   });
 
   it('should contain filesConfig passed as parameter and in correct format', function() {
     expect(indexHtml.contents.toString()).to.contain('var filesConfig = []');
   });
 
-  it('should define application root', function() {
-    expect(indexHtml.contents.toString()).to.contain('<base href="/my-styleguide-book/" />');
-  });
 });
 
 describe('styleguide_pseudo_styles.css', function() {
-  var styleguideFile;
-  this.timeout(5000);
+  
+  assertions.pseudoStyles.register();
 
   before(function(done) {
+    this.timeout(5000);
     var files = [];
     styleguideApplyStylesStream().pipe(
       through.obj({objectMode: true}, collector(files), function(callback) {
-        styleguideFile = findFile(files, 'styleguide_pseudo_styles.css');
+        var styleguideFile = findFile(files, 'styleguide_pseudo_styles.css');
+        assertions.pseudoStyles.set(styleguideFile);
         callback();
         done();
       })
     );
   });
 
-  it('should exist', function() {
-    expect(styleguideFile).to.be.an('object');
-  });
-
-  it('should contain pseudo classes converted to normal class names', function() {
-    expect(styleguideFile.contents.toString()).to.contain('.test-style.pseudo-class-hover {');
-    expect(styleguideFile.contents.toString()).to.contain('.test-style.pseudo-class-active {');
-  });
-
-  it('should not contain content from sourcemaps file', function() {
-    expect(styleguideFile.contents.toString()).not.to.contain('{{test.map content}}');
-  });
 });
 
 describe('styleguide_at_rules.css', function() {

--- a/test/integration/structure.test.js
+++ b/test/integration/structure.test.js
@@ -84,31 +84,22 @@ describe('styleguide_pseudo_styles.css', function() {
 });
 
 describe('styleguide_at_rules.css', function() {
-  var styleguideFile;
-  this.timeout(5000);
+
+  assertions.atRules.register();
 
   before(function(done) {
+    this.timeout(5000);
     var files = [];
     styleguideApplyStylesStream().pipe(
       through.obj({objectMode: true}, collector(files), function(callback) {
-        styleguideFile = findFile(files, 'styleguide_at_rules.css');
+        var styleguideFile = findFile(files, 'styleguide_at_rules.css');
+        assertions.atRules.set(styleguideFile);
         callback();
         done();
       })
     );
   });
 
-  it('should exist', function() {
-    expect(styleguideFile).to.be.an('object');
-  });
-
-  it('should contain at rules', function() {
-    expect(styleguideFile.contents.toString()).to.contain('@keyframes myanimation {');
-  });
-
-  it('should not contain content from sourcemaps file', function() {
-    expect(styleguideFile.contents.toString()).not.to.contain('{{test.map content}}');
-  });
 });
 
 describe('overview.html', function() {

--- a/test/integration/test-config.js
+++ b/test/integration/test-config.js
@@ -1,12 +1,14 @@
+var path = require('path');
+
 module.exports = {
   title: 'Test Styleguide',
-  overviewPath: 'test/projects/scss-project/source/test_overview.md',
+  overviewPath: path.resolve(__dirname, '../projects/scss-project/source/test_overview.md'),
   appRoot: '/my-styleguide-book',
   extraHead: [
     '<link rel="stylesheet" type="text/css" href="your/custom/style.css">',
     '<script src="your/custom/script.js"></script>'
   ],
   commonClass: ['custom-class-1', 'custom-class-2'],
-  styleVariables: 'test/projects/scss-project/source/styles/_styleguide_variables.scss',
+  styleVariables: path.resolve(__dirname, '../projects/scss-project/source/styles/_styleguide_variables.scss'),
   filesConfig: []
 };

--- a/test/integration/test-config.js
+++ b/test/integration/test-config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  title: 'Test Styleguide',
+  overviewPath: 'test/projects/scss-project/source/test_overview.md',
+  appRoot: '/my-styleguide-book',
+  extraHead: [
+    '<link rel="stylesheet" type="text/css" href="your/custom/style.css">',
+    '<script src="your/custom/script.js"></script>'
+  ],
+  commonClass: ['custom-class-1', 'custom-class-2'],
+  styleVariables: 'test/projects/scss-project/source/styles/_styleguide_variables.scss',
+  filesConfig: []
+};

--- a/test/unit/modules/cli/argv.test.js
+++ b/test/unit/modules/cli/argv.test.js
@@ -7,7 +7,7 @@ var path = require('path'),
   argv = require(path.resolve(__dirname, '../../../../lib/modules/cli/argv')),
   mockApi = ['usage', 'example', 'demand', 'describe'],
   required = ['kssSource', 'styleSource', 'output'],
-  optional = ['title', 'extraHead', 'commonClass', 'appRoot', 'styleVariables', 'server', 'port', 'watch'];
+  optional = ['title', 'extraHead', 'commonClass', 'appRoot', 'styleVariables', 'server', 'overviewPath', 'port', 'watch'];
 
 chai.use(require('sinon-chai'));
 


### PR DESCRIPTION
Use the same assertions on the style guides generated via the executable as used in test/integration/structure.test.js