### PR TITLE
Change route to root instead of overview

### DIFF
--- a/lib/app/views/main.html
+++ b/lib/app/views/main.html
@@ -4,7 +4,7 @@
 <header class="sg header" ng-class="{'desigerToolVisible' : designerTool.isVisible, 'error' : status.hasError}">
   <div class="inner">
     <div class="title">
-      <a ng-href="/overview">
+      <a ng-href="/">
         <h1 ng-hide="status.hasError" class="sg">{{ config.data.title }}</h1>
         <h1 ng-if="status.hasError">Error: {{status.error.name}}</h1>
       </a>


### PR DESCRIPTION
Signed-off-by: Ethel Ng <ethel@ustwo.com>

'/overview' leads to a 404. The correct route should just be '/'.