### PR TITLE
Fix bug on split comment into blocks

### DIFF
--- a/lib/modules/kss-additional-params.js
+++ b/lib/modules/kss-additional-params.js
@@ -8,6 +8,14 @@ function trimLinebreaks(str) {
   return str.replace(/^[\r\n]+|[\r\n]+$/g, '');
 }
 
+function standardizeLinebreaks(str) {
+  // Replace windows and mac line endings to unix line endings convention
+  if (!str) {
+    return str;
+  }
+  return str.replace(/\r?\n|\r/g, '\n');
+}
+
 // A list of params which need values parsing
 var ComplexParams = [
   'sg-angular-directive'
@@ -23,7 +31,8 @@ module.exports = {
       additionalKssParams = {},
       _this = this;
 
-    comment = trimLinebreaks(comment);
+    comment = standardizeLinebreaks(comment);	
+	  comment = trimLinebreaks(comment);
 
     comment.split('\n\n').forEach(function(markUpBlock) {
 

--- a/lib/modules/kss-additional-params.js
+++ b/lib/modules/kss-additional-params.js
@@ -31,8 +31,8 @@ module.exports = {
       additionalKssParams = {},
       _this = this;
 
-    comment = standardizeLinebreaks(comment);	
-	  comment = trimLinebreaks(comment);
+    comment = standardizeLinebreaks(comment);
+    comment = trimLinebreaks(comment);
 
     comment.split('\n\n').forEach(function(markUpBlock) {
 


### PR DESCRIPTION
Fix bug on split comment into blocks on non-UNIX systems standardizing line endings to UNIX line ending convention.