### PR TITLE
Catch errors when finding used variables

### DIFF
--- a/lib/styleguide.js
+++ b/lib/styleguide.js
@@ -120,9 +120,17 @@ function basenameOf(p) {
 function appendUsedVariablesToEachBlock(opt, styleguide) {
   // Go trough every styleguide style block and find used variables
   styleguide.sections.forEach(function(section) {
-    if (section.css) {
-      section.variables = variableParser.findVariables(section.css, section.syntax);
+    // It is possible that the CSS is not valid anymore after it is splitted to sections
+    // We need to catch possible parsing errors
+    try {
+      if (section.css) {
+        section.variables = variableParser.findVariables(section.css, section.syntax);
+      }
+    } catch (e) {
+      console.error('Could not parse used variables from section', section.reference + ':');
+      console.error(e.toString());
     }
+
     variableParser.findModifierVariables(section.modifiers).forEach(function(varName) {
       if (!section.variables || section.variables.indexOf(varName) === -1) {
         section.variables = section.variables || [];


### PR DESCRIPTION
It is possible that the CSS is not valid anymore after it is spliced to sections.
We need to catch possible parsing errors