### PR TITLE
Features/issue 546 less variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ demo-output
 phantomjs.log
 *.sublime-*
 coverage
+.idea
+.DS_Store

--- a/lib/app/js/app.js
+++ b/lib/app/js/app.js
@@ -157,7 +157,7 @@ angular.module('sgApp', [
       }
 
       angular.forEach(sortedVariables, function(variable) {
-        str = str.replace(new RegExp('\\$' + variable.name, 'g'), variable.value);
+        str = str.replace(new RegExp('\[\$\@]' + variable.name, 'g'), variable.value);
       });
       return str;
     };

--- a/test/angular/unit/app.test.js
+++ b/test/angular/unit/app.test.js
@@ -39,57 +39,101 @@ describe('sgApp module', function() {
       setVariables = $filter('setVariables');
     }));
 
-    it('should set a single variable correctly', function() {
-      var input = 'background: $color;',
-        variables = [
-          {name: 'color', value: '#FF0000'}
-        ],
-        result = 'background: #FF0000;';
-      expect(setVariables(input, variables)).to.eql(result);
+    describe('incomplete parameters', function() {
+      it('should return empty string if string is not defined', function() {
+        expect(setVariables(null, {})).to.eql('');
+      });
+
+      it('should return unmodified string if variables is not defined', function() {
+        expect(setVariables('test string', null)).to.eql('test string');
+      });
     });
 
-    it('should set multiple variables correctly', function() {
-      var input = 'background: $bgColor; color: $textColor;',
-        variables = [
-          {name: 'bgColor', value: '#FF0000'},
-          {name: 'textColor', value: '#00FF00'}
-        ],
-        result = 'background: #FF0000; color: #00FF00;';
-      expect(setVariables(input, variables)).to.eql(result);
+    describe('SASS / SCSS "$" variables', function() {
+      it('should set a single SASS / SCSS variable correctly', function() {
+        var input = 'background: $color;',
+          variables = [
+            {name: 'color', value: '#FF0000'}
+          ],
+          result = 'background: #FF0000;';
+        expect(setVariables(input, variables)).to.eql(result);
+      });
+
+      it('should set multiple SASS / SCSS variables correctly', function() {
+        var input = 'background: $bgColor; color: $textColor;',
+          variables = [
+            {name: 'bgColor', value: '#FF0000'},
+            {name: 'textColor', value: '#00FF00'}
+          ],
+          result = 'background: #FF0000; color: #00FF00;';
+        expect(setVariables(input, variables)).to.eql(result);
+      });
+
+      it('should set SASS / SCSS variables correctly if the first variable name is seconds substring', function() {
+        var input = 'background: $bgColor; color: $bgColor-light;',
+          variables = [
+            {name: 'bgColor', value: '#FF0000'},
+            {name: 'bgColor-light', value: '#00FF00'}
+          ],
+          result = 'background: #FF0000; color: #00FF00;';
+        expect(setVariables(input, variables)).to.eql(result);
+      });
+
+      it('should be case sensitive', function() {
+        var input = 'background: $test;',
+          variables = [
+            {name: 'Test', value: '#FF0000'}
+          ],
+          result = 'background: $test;';
+        expect(setVariables(input, variables)).to.eql(result);
+      });
     });
 
-    it('should set variables correctly if the first vairbale name is seconds substring', function() {
-      var input = 'background: $bgColor; color: $bgColor-light;',
-        variables = [
-          {name: 'bgColor', value: '#FF0000'},
-          {name: 'bgColor-light', value: '#00FF00'}
-        ],
-        result = 'background: #FF0000; color: #00FF00;';
-      expect(setVariables(input, variables)).to.eql(result);
-    });
+    describe('LESS "@" variables', function() {
+      it('should set a single LESS variable correctly', function() {
+        var input = 'background: @color;',
+          variables = [
+            {name: 'color', value: '#FF0000'}
+          ],
+          result = 'background: #FF0000;';
+        expect(setVariables(input, variables)).to.eql(result);
+      });
 
-    it('should be case sensitive', function() {
-      var input = 'background: $test;',
-        variables = [
-          {name: 'Test', value: '#FF0000'}
-        ],
-        result = 'background: $test;';
-      expect(setVariables(input, variables)).to.eql(result);
-    });
+      it('should set multiple LESS variables correctly', function() {
+        var input = 'background: @bgColor; color: @textColor;',
+          variables = [
+            {name: 'bgColor', value: '#FF0000'},
+            {name: 'textColor', value: '#00FF00'}
+          ],
+          result = 'background: #FF0000; color: #00FF00;';
+        expect(setVariables(input, variables)).to.eql(result);
+      });
 
-    it('should return empty string if string is not defined', function() {
-      expect(setVariables(null, {})).to.eql('');
-    });
+      it('should set LESS variables correctly if the first variable name is seconds substring', function() {
+        var input = 'background: @bgColor; color: @bgColor-light;',
+          variables = [
+            {name: 'bgColor', value: '#FF0000'},
+            {name: 'bgColor-light', value: '#00FF00'}
+          ],
+          result = 'background: #FF0000; color: #00FF00;';
+        expect(setVariables(input, variables)).to.eql(result);
+      });
 
-    it('should return unmodified string if variables is not defined', function() {
-      expect(setVariables('test string', null)).to.eql('test string');
+      it('should be case sensitive', function() {
+        var input = 'background: @test;',
+          variables = [
+            {name: 'Test', value: '#FF0000'}
+          ],
+          result = 'background: @test;';
+        expect(setVariables(input, variables)).to.eql(result);
+      });
     });
   });
 
   describe('addWrapper filter', function() {
 
     var addWrapper,
-        Styleguide;
+      Styleguide;
 
     beforeEach(function() {
       Styleguide = {
@@ -125,7 +169,7 @@ describe('sgApp module', function() {
     it('returns input wrapped inside a <sg-common-class-wrapper> tag with common class if Styleguide config has commonClass', function() {
       Styleguide.config.data.commonClass = 'my-common-class';
       var input = 'wrapped',
-          expected = '<sg-common-class-wrapper class="my-common-class">wrapped</sg-common-class-wrapper>';
+        expected = '<sg-common-class-wrapper class="my-common-class">wrapped</sg-common-class-wrapper>';
       expect(addWrapper(input)).to.eql(expected);
     });
 


### PR DESCRIPTION
Proposed fix for setVariables Filter not resolving LESS variables (i.e. with "@" prefix) properly. ( #546 )

Modified the RegExp expression in this source in setVariables,
```
      angular.forEach(sortedVariables, function(variable) {
        str = str.replace(new RegExp('\\$' + variable.name, 'g'), variable.value);
      });
```
to this,
```
      angular.forEach(sortedVariables, function(variable) {
        str = str.replace(new RegExp('\[\$\@]' + variable.name, 'g'), variable.value);
      });
```

Created new specs for the angular unit tests.
