### PR TITLE
Define border also on input focus styles

### DIFF
--- a/lib/app/sass/app.scss
+++ b/lib/app/sass/app.scss
@@ -272,6 +272,7 @@ input.sg {
 
   &:focus {
     background-color: $tertiary-color;
+    border: 1px solid $secondary-color;
   }
 }
 


### PR DESCRIPTION
When shadow DOM is disables this property could easily leak from user defined styles