### PR TITLE
Support special characters on page title and on designer tool, fixes #664

### DIFF
--- a/lib/app/index.html
+++ b/lib/app/index.html
@@ -42,7 +42,7 @@
       @import url('{{{appRoot}}}/css/styleguide_helper_elements.css');
     </style>
   </script>
-  <title ng-bind="$root.pageTitle">{{title}}</title>
+  <title ng-bind-html="$root.pageTitle | unsafe">{{title}}</title>
   {{{extraHead}}}
   {{#filesConfig}}
   <script type="text/javascript">

--- a/lib/app/views/partials/design.html
+++ b/lib/app/views/partials/design.html
@@ -12,7 +12,7 @@
     </div>
     <a class="sg" ng-click="showRelated = true" ng-hide="showRelated">Show only related variables</a>
     <a class="sg" ng-click="showRelated = false" ng-show="showRelated">Show all variables</a>
-    <h3 class="sg" ng-show="showRelated">{{currentReference.section.reference}} {{currentReference.section.header}}</h3>
+    <h3 class="sg" ng-show="showRelated">{{currentReference.section.reference}} <span ng-bind-html="currentReference.section.header | unsafe"></span></h3>
     <h3 class="sg" ng-hide="showRelated">All variables</h3>
     <ul class="sg">
       <li ng-hide="showRelated" ng-repeat="variable in variables">


### PR DESCRIPTION
Since we need to trust JSON contents anyway, it is not a problem to use unsafe filter.