### PR TITLE
Feature/add section reference feature

### DIFF
--- a/lib/modules/wrapper-markup.js
+++ b/lib/modules/wrapper-markup.js
@@ -36,35 +36,78 @@ function buildReferenceDictionary(sections) {
   return index;
 }
 
-module.exports.generateSectionWrapperMarkup = function(sections) {
-  /* Calculate own wrapper */
-  var wrapper,
-    wrapperKeyword = '<sg-wrapper-content/>',
-    index = buildReferenceDictionary(sections);
+function generateSectionWrapperMarkup(sections, index) {
+    /* Calculate own wrapper */
+    var wrapper,
+        wrapperKeyword = '<sg-wrapper-content/>';
 
-  return sections.map(function(section) {
-    wrapper = section['sg-wrapper'] || wrapperKeyword;
-    /* Wrap a wrapper with a parent wrapper */
-    if (section.parentReference) {
-      var parentWrapper = index[section.parentReference].wrapper;
-      wrapper = parentWrapper.replace(wrapperKeyword, wrapper);
-    }
-    section.wrapper = wrapper;
-    if (section.markup) {
-      /* Wrap markup */
-      section.wrappedMarkup = section.markup;
-      section.wrappedMarkup = section.wrapper.replace(wrapperKeyword, section.markup);
-    }
+    return sections.map(function(section) {
+        wrapper = section['sg-wrapper'] || wrapperKeyword;
+        /* Wrap a wrapper with a parent wrapper */
+        if (section.parentReference) {
+            var parentWrapper = index[section.parentReference].wrapper;
+            wrapper = parentWrapper.replace(wrapperKeyword, wrapper);
+        }
 
-    /* Wrap modifiers */
-    section.modifiers.forEach(function(modifier) {
-      /* Wrap modifier markup */
-      modifier.wrappedMarkup = modifier.markup;
-      modifier.wrappedMarkup = section.wrapper.replace(wrapperKeyword, modifier.markup);
+        section.wrapper = wrapper;
+        if (section.markup) {
+            /* Wrap markup */
+            section.wrappedMarkup = section.markup;
+            section.wrappedMarkup = section.wrapper.replace(wrapperKeyword, section.markup);
+        }
+
+        /* Wrap modifiers */
+        section.modifiers.forEach(function(modifier) {
+            /* Wrap modifier markup */
+            modifier.wrappedMarkup = modifier.markup;
+            modifier.wrappedMarkup = section.wrapper.replace(wrapperKeyword, modifier.markup);
+        });
+
+        /* Clean nested sections */
+        delete section.sections;
+        return section;
     });
+}
 
-    /* Clean nested sections */
-    delete section.sections;
-    return section;
-  });
+function replaceSectionVariables(sections, index) {
+    return sections.map(function(section) {
+        var sectionContentVariable = /\<sg\-content\>(.*)\<\/sg\-content\>/;
+        while ((result = sectionContentVariable.exec(section.markup))) {
+            var sectionContentIdentifier = result[1],
+                referencedSectionContent = '',
+                sectionContentReferenceTag = '<sg-content>' + sectionContentIdentifier + '</sg-content>';
+
+            if (index.hasOwnProperty(sectionContentIdentifier) && index[sectionContentIdentifier].markup != 'undefined') {
+                referencedSectionContent = index[sectionContentIdentifier].markup;
+                // replace modifiers from referenced section
+                referencedSectionContent = referencedSectionContent.replace('{$modifiers}','');
+            }
+            if (referencedSectionContent == '') {
+                referencedSectionContent = '[ERROR: Referenced section ' + sectionContentIdentifier + ' has no markup!]';
+            } else if (referencedSectionContent.search(sectionContentReferenceTag) > 0) {
+                console.log('You can\'t reference a section that references the section back as this will end in an endless loop');
+                referencedSectionContent = '[ERROR: Reference to ' + sectionContentIdentifier + ' failed!]';
+            }
+            section.markup = section.markup.replace(sectionContentReferenceTag, referencedSectionContent);
+            section.wrappedMarkup = section.wrappedMarkup.replace(sectionContentReferenceTag, referencedSectionContent);
+
+            /* Wrap modifiers */
+            section.modifiers.forEach(function(modifier) {
+                /* Wrap modifier markup */
+                modifier.markup = modifier.markup.replace(sectionContentReferenceTag, referencedSectionContent);
+                modifier.wrappedMarkup = modifier.wrappedMarkup.replace(sectionContentReferenceTag, referencedSectionContent);
+            });
+        }
+        return section;
+    });
+}
+
+
+module.exports.replaceSectionVariables = function(sections) {
+    var index = buildReferenceDictionary(sections);
+
+    sections = generateSectionWrapperMarkup(sections, index);
+    sections = replaceSectionVariables(sections, index);
+
+    return sections;
 };

--- a/lib/styleguide.js
+++ b/lib/styleguide.js
@@ -65,8 +65,8 @@ function emitCompileSuccess() {
   }
 }
 
-function generateInheritedWrappers(json) {
-  json.sections = wrapperMarkup.generateSectionWrapperMarkup(json.sections);
+function replaceSectionVariables(json) {
+  json.sections = wrapperMarkup.replaceSectionVariables(json.sections);
 }
 
 function copyUsedOptionsToJsonConfig(opt, json) {
@@ -221,7 +221,7 @@ module.exports.generate = function(options) {
           });
         }
 
-        generateInheritedWrappers(styleguide);
+        replaceSectionVariables(styleguide);
         copyUsedOptionsToJsonConfig(opt, styleguide);
         appendUsedVariablesToEachBlock(opt, styleguide);
         addFileHashesAndReplaceAbsolutePaths(styleguide);


### PR DESCRIPTION
In the markup of a section other sections markup can now be referenced
by using the `<sg-content>1.2.3</sg-content>` syntax.