### PR TITLE
Refactor variable setter. Fixes variable saving issues. Add test cases

### DIFF
--- a/lib/modules/parsers/less.js
+++ b/lib/modules/parsers/less.js
@@ -83,47 +83,38 @@ function setVariables(string, variables) {
   });
 
   variables.forEach(function(variable) {
-    ast.map(function(node) {
-      if (node.type === 'atrules') {
-        var hasOperator = false,
-          isThisVariable = false,
-          metOperator = false,
-          metFirstSpace = false,
-          newContent = [];
-        node.map(function(nnode) {
-          if (nnode.type === 'ident' && nnode.content === variable.name) {
-            isThisVariable = true;
-          }
-          if (nnode.type === 'operator' && nnode.content === ':') {
-            metOperator = true;
-            hasOperator = true;
-          }
-        });
-        // Take only at-rules with operators
-        if (!hasOperator) {
-          return;
+    traverser.traverse(ast, {
+      // Visitor for SASS, SCSS and plain CSS syntaxes
+      test: function(name) {
+        return name === 'atrules';
+      },
+      process: function(nodes) {
+        var varName = nodes.content[0].content[0].content;
+
+        // Skip at-keywords that do not decrade variable (Ex. @imports)
+        if (varName === variable.name && nodes.content[1].type === 'operator' && nodes.content[1].content === ':') {
+          /* Grabs all the listed values
+          * Fix then https://github.com/tonyganch/gonzales-pe/issues/17 is fixed */
+
+          nodes.content = nodes.content.filter(function(element, index) {
+            if (index === 0 && (element.type === 'atrules' || element.type === 'atkeyword')) {
+              return true;
+            }
+            if (index === 1 && element.type === 'operator' && element.content === ':') {
+              return true;
+            }
+            // Preserver only leading spaces
+            if (index === 2 && element.type === 'space') {
+              return true;
+            }
+            return false;
+          });
+
+          nodes.content.push({
+            type: 'string',
+            content: variable.value
+          });
         }
-        // For given variable only
-        if (!isThisVariable) {
-          return;
-        }
-        node.content.forEach(function(node) {
-          if (metOperator && metFirstSpace) {
-            return;
-          }
-          if (node.type === 'operator') {
-            metOperator = true;
-          }
-          newContent.push(node);
-          if (node.type === 'space' && metOperator) {
-            metFirstSpace = true;
-          }
-        });
-        node.content = newContent;
-        node.content.push({
-          type: 'string',
-          content: variable.value
-        });
       }
     });
   });

--- a/lib/modules/parsers/scss.js
+++ b/lib/modules/parsers/scss.js
@@ -27,7 +27,7 @@ function parseVariableDeclarations(string) {
           if (nodes.content[3]) {
             out.push({
               name: varName,
-              value: nodes.content[3].toCSS('scss'),
+              value: nodes.content[3].toCSS(syntax),
               line: nodes.content[3].start.line
             });
           }
@@ -71,31 +71,20 @@ function setVariables(string, variables) {
   });
 
   variables.forEach(function(variable) {
-    ast.map(function(node) {
-      if (node.type === 'declaration') {
-        var isThisVariable = false;
-        node.map(function(nnode) {
-          if (nnode.type === 'variable') {
-            nnode.map(function(nnnode) {
-              if (nnnode.type === 'ident' && nnnode.content === variable.name) {
-                isThisVariable = true;
-              }
-            });
-          }
-        });
-        if (isThisVariable) {
-          node.map(function(nnode) {
-            if (nnode.type === 'value' && nnode.content[0].type !== 'variable') {
-              nnode.content = [{
-                type: 'string',
-                content: variable.value
-              }];
-            }
-          });
+    traverser.traverse(ast, {
+      // Visitor for SASS, SCSS and plain CSS syntaxes
+      test: function(name, nodes) {
+        return name === 'declaration' && nodes.content[0].content[0].type === 'variable';
+      },
+      process: function(nodes) {
+        var varName = nodes.content[0].content[0].content[0].content;
+        if (varName === variable.name && nodes.content[3]) {
+          nodes.content[3].content = variable.value;
         }
       }
     });
   });
+
   return ast.toCSS(syntax);
 }
 

--- a/test/unit/modules/parsers/less.test.js
+++ b/test/unit/modules/parsers/less.test.js
@@ -253,6 +253,26 @@ describe('LESS parser', function() {
       expect(changed).eql(result);
     });
 
+    it('should not change variable when declaration contains the same variable in the function', function() {
+      var str = multiline(function() {
+          /*
+           @mycolor: #0000ff;
+           @another: lighten(@mycolor, 10%);
+           */
+        }),
+        variables = [
+          {name: 'mycolor', value: '#ffffff'}
+        ],
+        result = multiline(function() {
+          /*
+           @mycolor: #ffffff;
+           @another: lighten(@mycolor, 10%);
+           */
+        }),
+        changed = parser.setVariables(str, variables);
+      expect(changed).eql(result);
+    });
+
     it('should preserve indents', function() {
       var str = multiline(function() {
           /*

--- a/test/unit/modules/parsers/scss.test.js
+++ b/test/unit/modules/parsers/scss.test.js
@@ -252,6 +252,26 @@ describe('SCSS parser', function() {
       expect(changed).eql(result);
     });
 
+    it('should not change variable when declaration contains the same variable in the function', function() {
+      var str = multiline(function() {
+          /*
+           $mycolor: #0000ff;
+           $another: lighten($mycolor, 10%);
+           */
+        }),
+        variables = [
+          {name: 'mycolor', value: '#ffffff'}
+        ],
+        result = multiline(function() {
+          /*
+           $mycolor: #ffffff;
+           $another: lighten($mycolor, 10%);
+           */
+        }),
+        changed = parser.setVariables(str, variables);
+      expect(changed).eql(result);
+    });
+
     it('should change single value variable', function() {
       var str = multiline(function() {
           /*
@@ -441,6 +461,26 @@ describe('SASS parser', function() {
            $primary-color: #00ff00
            .foo
              background-color: $primary-color
+           */
+        }),
+        changed = parser.setVariables(str, variables);
+      expect(changed).eql(result);
+    });
+
+    it('should not change variable when declaration contains the same variable in the function', function() {
+      var str = multiline(function() {
+          /*
+           $mycolor: #0000ff
+           $another: lighten($mycolor, 10%)
+           */
+        }),
+        variables = [
+          {name: 'mycolor', value: '#ffffff'}
+        ],
+        result = multiline(function() {
+          /*
+           $mycolor: #ffffff
+           $another: lighten($mycolor, 10%)
            */
         }),
         changed = parser.setVariables(str, variables);


### PR DESCRIPTION
Fixes issue when wrong variable was saved when save variable name was used inside a function in the variable value: `$another: lighten($mycolor, 10%);`