### PR TITLE
Make navigation links for a fullscreen view the same when visited and not

### DIFF
--- a/lib/app/sass/app.scss
+++ b/lib/app/sass/app.scss
@@ -1190,6 +1190,13 @@ Styleguide 4.4
     float: left;
     cursor: pointer;
   }
+  .sg-navigation-link,
+  .sg-navigation-link:link,
+  .sg-navigation-link:visited
+  {
+    color: $default-action-color;
+    text-decoration: none;
+  }
 }
 
 .sg.disconnection-icon {

--- a/lib/app/views/element-fullscreen.html
+++ b/lib/app/views/element-fullscreen.html
@@ -1,8 +1,14 @@
 <div class="sg-navigation-section">
-  <a ng-hide="!previousSection" ui-sref="app.fullscreen({section: previousSection })">
+  <a
+    ng-hide="!previousSection"
+    ui-sref="app.fullscreen({section: previousSection })"
+    class="sg-navigation-link">
     <i class="fa fa-arrow-left"></i>
   </a>
-  <a ng-hide="!nextSection" ui-sref="app.fullscreen({section: nextSection })">
+  <a
+    ng-hide="!nextSection"
+    ui-sref="app.fullscreen({section: nextSection })"
+    class="sg-navigation-link">
     <i class="fa fa-arrow-right"></i>
   </a>
 </div>


### PR DESCRIPTION
Navigation links have default colors, which makes them purple when they are visited. This is crucial for automatic visual testing (comparing screenshots of development and production version of the interface).
The change gives the navigation links permanent color.
Also, it is nice in general that a visible element has class and can be styled.