### PR TITLE
Show KSS parse errors

### DIFF
--- a/lib/modules/kss-parser.js
+++ b/lib/modules/kss-parser.js
@@ -143,6 +143,10 @@ function processFile(contents, filePath, syntax, options) {
         }
         return memo;
       }, []));
+    })
+    .catch(function(err) {
+      console.error('Styleguide generation failed');
+      console.error('Error: %s in %s', err, filePath);
     });
   });
 }


### PR DESCRIPTION
Solves silent styleguide's generation fail on KSS errors. Issue: https://github.com/SC5/sc5-styleguide/issues/765