### PR TITLE
Renamed wrappedMarkup property into renderMarkupPropery

### DIFF
--- a/lib/app/js/controllers/element.js
+++ b/lib/app/js/controllers/element.js
@@ -101,7 +101,7 @@ angular.module('sgApp')
         $scope.nextSection = nextSection(sections, result);
         $scope.section = element;
         $scope.variables = Variables.variables;
-        $scope.markup = $filter('setVariables')($filter('setModifierClass')(element.wrappedMarkup, element.className), $scope.variables);
+        $scope.markup = $filter('setVariables')($filter('setModifierClass')(element.renderMarkup, element.className), $scope.variables);
       }
     }
   });

--- a/lib/app/js/controllers/sections.js
+++ b/lib/app/js/controllers/sections.js
@@ -38,7 +38,7 @@ angular.module('sgApp')
     }
 
     $scope.isEmptyMainSection = function(section) {
-      return section.reference.indexOf('.') === -1 && !section.wrappedMarkup && (!section.modifiers || section.modifiers.length === 0);
+      return section.reference.indexOf('.') === -1 && !section.renderMarkup && (!section.modifiers || section.modifiers.length === 0);
     };
 
     $scope.isActive = function(section) {

--- a/lib/app/views/partials/section.html
+++ b/lib/app/views/partials/section.html
@@ -26,7 +26,7 @@
       </a>
     </div>
     <shadow-dom>
-      <div ng-bind-html="mod.wrappedMarkup | setModifierClass: mod.className | setVariables: variables | addWrapper | unsafe" dynamic-compile></div>
+      <div ng-bind-html="mod.renderMarkup | setModifierClass: mod.className | setVariables: variables | addWrapper | unsafe" dynamic-compile></div>
     </shadow-dom>
   </div>
   <div ng-repeat-end></div>
@@ -40,7 +40,7 @@
     </div>
 
     <shadow-dom>
-      <div ng-bind-html="section.wrappedMarkup | setVariables: variables | addWrapper | unsafe" dynamic-compile></div>
+      <div ng-bind-html="section.renderMarkup | setVariables: variables | addWrapper | unsafe" dynamic-compile></div>
     </shadow-dom>
   </div>
 

--- a/lib/modules/wrapper-markup.js
+++ b/lib/modules/wrapper-markup.js
@@ -19,15 +19,15 @@ function generateSectionWrapperMarkup(sections) {
     section.wrapper = wrapper;
     if (section.markup) {
       /* Wrap markup */
-      section.wrappedMarkup = section.markup;
-      section.wrappedMarkup = section.wrapper.replace(wrapperKeyword, section.markup);
+      section.renderMarkup = section.markup;
+      section.renderMarkup = section.wrapper.replace(wrapperKeyword, section.markup);
     }
 
     /* Wrap modifiers */
     section.modifiers.forEach(function(modifier) {
       /* Wrap modifier markup */
-      modifier.wrappedMarkup = modifier.markup;
-      modifier.wrappedMarkup = section.wrapper.replace(wrapperKeyword, modifier.markup);
+      modifier.rederMarkup = modifier.markup;
+      modifier.renderMarkup = section.wrapper.replace(wrapperKeyword, modifier.markup);
     });
 
     /* Clean nested sections */

--- a/test/angular/unit/controllers/element.test.js
+++ b/test/angular/unit/controllers/element.test.js
@@ -24,7 +24,7 @@ describe('ElementCtrl', function() {
                 id: 1
               }
             ],
-            wrappedMarkup: '<div>foo</div>'
+            renderMarkup: '<div>foo</div>'
           }
         ]
       },

--- a/test/angular/unit/controllers/sections.test.js
+++ b/test/angular/unit/controllers/sections.test.js
@@ -91,7 +91,7 @@ describe('SectionsCtrl', function() {
       var section = {
         header: 'Section header text',
         reference: '1',
-        wrappedMarkup: '',
+        renderMarkup: '',
         markup: ''
       };
       expect(scope.isEmptyMainSection(section)).to.eql(true);
@@ -101,7 +101,7 @@ describe('SectionsCtrl', function() {
       var section = {
         header: 'Section header text',
         reference: '1.1',
-        wrappedMarkup: '',
+        renderMarkup: '',
         markup: ''
       };
       expect(scope.isEmptyMainSection(section)).to.eql(false);
@@ -111,7 +111,7 @@ describe('SectionsCtrl', function() {
       var section = {
         header: 'Section header text',
         reference: '1',
-        wrappedMarkup: '<p>Test</p>',
+        renderMarkup: '<p>Test</p>',
         markup: '<p>Test</p>'
       };
       expect(scope.isEmptyMainSection(section)).to.eql(false);

--- a/test/unit/modules/wrapper-markup.test.js
+++ b/test/unit/modules/wrapper-markup.test.js
@@ -125,32 +125,32 @@ describe('KSS wrapper markup generator', function() {
 
   it('should not add wrapper to the parent sections', function() {
     var wrappedMarkup = '<container></container>';
-    expect(removeLinebreaks(json.sections[0].wrappedMarkup)).eql(wrappedMarkup);
+    expect(removeLinebreaks(json.sections[0].renderMarkup)).eql(wrappedMarkup);
   });
 
   it('should add wrapper markup to the current section', function() {
     var wrappedMarkup = '<outer-wrapper><p>Content inside outer wrapper</p></outer-wrapper>';
-    expect(removeLinebreaks(json.sections[1].wrappedMarkup)).eql(wrappedMarkup);
+    expect(removeLinebreaks(json.sections[1].renderMarkup)).eql(wrappedMarkup);
   });
 
   it('should inherit wrapper markup to the subsection', function() {
     var wrappedMarkup = '<outer-wrapper><p>Content inside outer wrapper</p></outer-wrapper>';
-    expect(removeLinebreaks(json.sections[2].wrappedMarkup)).eql(wrappedMarkup);
+    expect(removeLinebreaks(json.sections[2].renderMarkup)).eql(wrappedMarkup);
   });
 
   it('should inherit wrapper markup to the subsection with the current wrapper markup', function() {
     var wrappedMarkup = '<outer-wrapper><inner-wrapper><p>Content inside inner and outer wrapper</p></inner-wrapper></outer-wrapper>';
-    expect(removeLinebreaks(json.sections[3].wrappedMarkup)).eql(wrappedMarkup);
+    expect(removeLinebreaks(json.sections[3].renderMarkup)).eql(wrappedMarkup);
   });
 
   it('should inherit all parent wrapper markups to the sub-sub-section', function() {
     var wrappedMarkup = '<outer-wrapper><inner-wrapper><p>Second level content</p></inner-wrapper></outer-wrapper>';
-    expect(removeLinebreaks(json.sections[4].wrappedMarkup)).eql(wrappedMarkup);
+    expect(removeLinebreaks(json.sections[4].renderMarkup)).eql(wrappedMarkup);
   });
 
   it('should work for modifiers', function() {
     var wrappedMarkup = '<wrapper><button class="modifier"></button></wrapper>';
-    expect(removeLinebreaks(json.sections[5].modifiers[0].wrappedMarkup)).eql(wrappedMarkup);
+    expect(removeLinebreaks(json.sections[5].modifiers[0].renderMarkup)).eql(wrappedMarkup);
   });
 
 });


### PR DESCRIPTION
I made this renaming because the markup to render may have many transformations, not only to be wrapped. This will also matter in our future introduction of `sg-htmlMarkup` property.