### PR TITLE
Correct path to helper elements CSS. Fixes #799

### DIFF
--- a/lib/app/index.html
+++ b/lib/app/index.html
@@ -39,7 +39,7 @@
     <style>
       @import url('{{{appRoot}}}/styleguide.css');
       @import url('{{{appRoot}}}/styleguide_pseudo_styles.css');
-      @import url('{{{appRoot}}}/css/styleguide_helper_elements.css');
+      @import url('{{{appRoot}}}/styleguide_helper_elements.css');
     </style>
   </script>
   <title ng-bind-html="$root.pageTitle | unsafe">{{title}}</title>

--- a/test/integration/assert-index-html.js
+++ b/test/integration/assert-index-html.js
@@ -40,7 +40,7 @@ module.exports = (function() {
         describe('style imports', function() {
 
           var style,
-              expected = ['styleguide.css', 'styleguide_pseudo_styles.css', 'css/styleguide_helper_elements.css'];
+              expected = ['styleguide.css', 'styleguide_pseudo_styles.css', 'styleguide_helper_elements.css'];
 
           before(function() {
             var start = '<script type="text/ng-template" id="userStyles.html">',


### PR DESCRIPTION
Replaces the second occurrence of /css

See https://github.com/SC5/sc5-styleguide/commit/b8de9149b88dd08fb2600e71d078c45d2dfb2da4

Fixes #716 