### PR TITLE
Process sass files before giving them to styleguide for applying

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -8,6 +8,9 @@ var gulp = require('gulp'),
     runSequence = require('run-sequence'),
     toc = require('gulp-doctoc'),
     styleguide = require('./lib/styleguide'),
+    sass = require('gulp-sass'),
+    please = require('gulp-pleeease'),
+    neat = require('node-neat'),
     distPath = 'lib/dist',
     fs = require('fs'),
     chalk = require('chalk'),
@@ -86,7 +89,13 @@ gulp.task('dev:applystyles', () => {
     process.exit(1);
     return 1;
   }
-  return gulp.src([distPath + '/css/*.css'])
+  return gulp.src([distPath + '/sass/*.scss'])
+    .pipe(sass({
+        includePaths: neat.includePaths
+    }))
+    .pipe(please({
+        minifier: false
+    }))
     .pipe(styleguide.applyStyles())
     .pipe(gulp.dest(outputPath));
 });


### PR DESCRIPTION
Currently in dev mode styles are not applied to the components in shadowRoot. The generated `styleguide.css` is empty because there is no `distPath + '/css/*.css'` file (check on pure copy, or after removing `lib/dist`). The problem appeared on 0.3.20 version.

The proposed change solves the problem but it makes copy-paste with similar code of `lib/styleguide.js`.

Before:
<img width="1107" alt="screen shot 2015-11-24 at 10 54 55" src="https://cloud.githubusercontent.com/assets/27215/11362148/93548d26-929a-11e5-9a01-54216cfc43df.png">

After:
<img width="1129" alt="screen shot 2015-11-24 at 10 55 31" src="https://cloud.githubusercontent.com/assets/27215/11362153/9a61b7a6-929a-11e5-9e8d-b7e59a5435db.png">
