### PR TITLE
Run clean task before build to remove previous build results

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -127,10 +127,10 @@ gulp.task('dev', ['dev:doc', 'dev:static', 'dev:applystyles', 'dev:generate'], (
   gulp.watch('lib/styleguide.js', ['dev:generate']);
 });
 
-gulp.task('buildDist', ['sass', 'js:app', 'js:vendor', 'html', 'assets']);
+gulp.task('build:dist', ['sass', 'js:app', 'js:vendor', 'html', 'assets']);
 
 gulp.task('build', ['clean-dist'], () => {
-  runSequence('buildDist');
+  runSequence('build:dist');
 });
 
 gulp.task('changelog', () => {

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -11,6 +11,7 @@ var gulp = require('gulp'),
     sass = require('gulp-sass'),
     please = require('gulp-pleeease'),
     neat = require('node-neat'),
+    clean = require('gulp-clean'),
     distPath = 'lib/dist',
     fs = require('fs'),
     chalk = require('chalk'),
@@ -55,6 +56,11 @@ gulp.task('html', () => {
 gulp.task('assets', () => {
   return gulp.src('lib/app/assets/**')
     .pipe(gulp.dest(distPath + '/assets'));
+});
+
+gulp.task('clean-dist', function () {
+  return gulp.src(distPath, {read: false})
+    .pipe(clean());
 });
 
 // Copy test directives to output even when running gulp dev
@@ -121,7 +127,9 @@ gulp.task('dev', ['dev:doc', 'dev:static', 'dev:applystyles', 'dev:generate'], (
   gulp.watch('lib/styleguide.js', ['dev:generate']);
 });
 
-gulp.task('build', ['sass', 'js:app', 'js:vendor', 'html', 'assets']);
+gulp.task('build', ['clean-dist'], () => {
+  gulp.start(['sass', 'js:app', 'js:vendor', 'html', 'assets']);
+});
 
 gulp.task('changelog', () => {
 

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -127,8 +127,10 @@ gulp.task('dev', ['dev:doc', 'dev:static', 'dev:applystyles', 'dev:generate'], (
   gulp.watch('lib/styleguide.js', ['dev:generate']);
 });
 
+gulp.task('buildDist', ['sass', 'js:app', 'js:vendor', 'html', 'assets']);
+
 gulp.task('build', ['clean-dist'], () => {
-  gulp.start(['sass', 'js:app', 'js:vendor', 'html', 'assets']);
+  runSequence('buildDist');
 });
 
 gulp.task('changelog', () => {

--- a/package.json
+++ b/package.json
@@ -92,7 +92,8 @@
     "proxyquire": "~1.5.0",
     "requirefrom": "~0.2.0",
     "sinon": "~1.14.1",
-    "sinon-chai": "~2.8.0"
+    "sinon-chai": "~2.8.0",
+    "gulp-clean": "^0.3.1"
   },
   "scripts": {
     "pretest": "gulp clean-coverage",


### PR DESCRIPTION
The problem https://github.com/SC5/sc5-styleguide/pull/840 fixes would have been noticed a lot sooner if previous build results were cleared before the next build. 