### PR TITLE
Replace inserts in wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,7 +486,7 @@ In the markup you can insert markup of the other sections by referring to its se
 // List item
 //
 // markup:
-// <li>Item<li>
+// <li>Item</li>
 //
 // Styleguide 1.2.1
 ```

--- a/lib/modules/section-references.js
+++ b/lib/modules/section-references.js
@@ -4,57 +4,60 @@ var referenceDictionary = require('./reference-dictionary'),
 function replaceReferences(sections) {
   // TODO: Not to calculate twice
   var index = buildReferenceDictionary(sections);
-
   return sections.map(function(section) {
     var sectionContentVariable = /<sg\-insert>([0-9\.]*)(.*)<\/sg\-insert>/,
         result,
-        replacer = function(modifier) {
-          /* Wrap modifier markup */
-          modifier.markup = modifier.markup.replace(sectionContentReferenceTag, referencedSectionContent);
-        },
         modifierPlaceholder = /\{\$modifiers\}/g,
-        reduceModifiers = function(previousValue, currentValue) {
-          // Concat all modifiers
-          return previousValue + currentValue.markup.replace(modifierPlaceholder, currentValue.className);
-        };
-    while ((result = sectionContentVariable.exec(section.markup))) {
-      var sectionContentIdentifier = result[1],
-        sectionModifierIdentifier = result[2],
-        referencedSectionContent = '',
-        sectionContentReferenceTag = '<sg-insert>' + sectionContentIdentifier + sectionModifierIdentifier + '</sg-insert>';
-
-      if (index.hasOwnProperty(sectionContentIdentifier) && index[sectionContentIdentifier].markup !== 'undefined') {
-        referencedSectionContent = index[sectionContentIdentifier].markup;
-        // replace modifiers from referenced section
-        if (sectionModifierIdentifier !== '' && sectionModifierIdentifier.length > 1) {
-          sectionModifierIdentifier = sectionModifierIdentifier.substring(1);
-          // If all is the modifier insert all variants..
-          if (sectionModifierIdentifier === 'all') {
-            referencedSectionContent = index[sectionContentIdentifier].modifiers.reduce(reduceModifiers, '');
-          }else {
-            //Arrays start with 0, modifiers with 1 => subtract 1
-            sectionModifierIdentifier = parseInt(sectionModifierIdentifier, 10) - 1;
-            var modifiers = index[sectionContentIdentifier].modifiers;
-            // ..otherwise check if the modifier refered to exists
-            if (modifiers.hasOwnProperty(sectionModifierIdentifier) && modifiers[sectionModifierIdentifier].className !== 'undefined') {
-              var referencedModifierContent = index[sectionContentIdentifier].modifiers[sectionModifierIdentifier].className;
-              referencedSectionContent = referencedSectionContent.replace(modifierPlaceholder, referencedModifierContent);
-            }
+        finder = function (property) {
+          // Wrap modifiers
+          function replacerFactory (modifier) {
+            modifier.markup = modifier[property].replace(sectionContentReferenceTag, referencedSectionContent);
+            return modifier;
           }
-        }
-        referencedSectionContent = referencedSectionContent.replace(modifierPlaceholder, '');
-      }
-      if (referencedSectionContent === '') {
-        referencedSectionContent = '[ERROR: Referenced section ' + sectionContentIdentifier + ' has no markup!]';
-      } else if (referencedSectionContent.search(sectionContentReferenceTag) > 0) {
-        console.log('You can\'t reference a section that references the section back as this will end in an endless loop');
-        referencedSectionContent = '[ERROR: Reference to ' + sectionContentIdentifier + ' failed!]';
-      }
-      section.markup = section.markup.replace(sectionContentReferenceTag, referencedSectionContent);
+          // Concat all modifiers
+          function reduceModifiers (previousValue, currentValue) {
+            return previousValue + currentValue[property].replace(modifierPlaceholder, currentValue.className);
+          }
+          while ((result = sectionContentVariable.exec(section[property]))) {
+            var sectionContentIdentifier = result[1],
+              sectionModifierIdentifier = result[2],
+              referencedSectionContent = '',
+              sectionContentReferenceTag = '<sg-insert>' + sectionContentIdentifier + sectionModifierIdentifier + '</sg-insert>';
 
-      /* Wrap modifiers */
-      section.modifiers.forEach(replacer);
-    }
+            if (index.hasOwnProperty(sectionContentIdentifier) && index[sectionContentIdentifier][property] !== 'undefined') {
+              referencedSectionContent = index[sectionContentIdentifier].markup;
+              // replace modifiers from referenced section
+              if (sectionModifierIdentifier !== '' && sectionModifierIdentifier.length > 1) {
+                sectionModifierIdentifier = sectionModifierIdentifier.substring(1);
+                // If all is the modifier insert all variants..
+                if (sectionModifierIdentifier === 'all') {
+                  referencedSectionContent = index[sectionContentIdentifier].modifiers.reduce(reduceModifiers, '');
+                } else {
+                  //Arrays start with 0, modifiers with 1 => subtract 1
+                  sectionModifierIdentifier = parseInt(sectionModifierIdentifier, 10) - 1;
+                  var modifiers = index[sectionContentIdentifier].modifiers;
+                  // ..otherwise check if the modifier refered to exists
+                  if (modifiers.hasOwnProperty(sectionModifierIdentifier) && modifiers[sectionModifierIdentifier].className !== 'undefined') {
+                    var referencedModifierContent = index[sectionContentIdentifier].modifiers[sectionModifierIdentifier].className;
+                    referencedSectionContent = referencedSectionContent.replace(modifierPlaceholder, referencedModifierContent);
+                  }
+                }
+              }
+              referencedSectionContent = referencedSectionContent.replace(modifierPlaceholder, '');
+            }
+            if (referencedSectionContent === '') {
+              referencedSectionContent = '[ERROR: Referenced section ' + sectionContentIdentifier + ' has no markup!]';
+            } else if (referencedSectionContent.search(sectionContentReferenceTag) > 0) {
+              console.log('You can\'t reference a section that references the section back as this will end in an endless loop');
+              referencedSectionContent = '[ERROR: Reference to ' + sectionContentIdentifier + ' failed!]';
+            }
+            section[property] = section[property].replace(sectionContentReferenceTag, referencedSectionContent);
+
+            section.modifiers.forEach(replacerFactory);
+          }
+        };
+    finder('markup');
+    finder('sg-wrapper');
     return section;
   });
 }

--- a/lib/modules/section-references.js
+++ b/lib/modules/section-references.js
@@ -7,8 +7,7 @@ function findeAndReplace(section, property, index) {
       modifierPlaceholder = /\{\$modifiers\}/g;
   // Wrap modifiers
   function replacer (modifier) {
-    modifier.markup = modifier[property].replace(sectionContentReferenceTag, referencedSectionContent);
-    return modifier;
+    return ((modifier.markup = modifier[property].replace(sectionContentReferenceTag, referencedSectionContent)));
   }
   // Concat all modifiers
   function reduceModifiers (previousValue, currentValue) {

--- a/lib/modules/section-references.js
+++ b/lib/modules/section-references.js
@@ -1,63 +1,64 @@
 var referenceDictionary = require('./reference-dictionary'),
     buildReferenceDictionary = referenceDictionary.build;
 
+function findeAndReplace(section, property, index) {
+  var sectionContentVariable = /<sg\-insert>([0-9\.]*)(.*)<\/sg\-insert>/,
+      result,
+      modifierPlaceholder = /\{\$modifiers\}/g;
+  // Wrap modifiers
+  function replacer (modifier) {
+    modifier.markup = modifier[property].replace(sectionContentReferenceTag, referencedSectionContent);
+    return modifier;
+  }
+  // Concat all modifiers
+  function reduceModifiers (previousValue, currentValue) {
+    return previousValue + currentValue[property].replace(modifierPlaceholder, currentValue.className);
+  }
+  while ((result = sectionContentVariable.exec(section[property]))) {
+    var sectionContentIdentifier = result[1],
+      sectionModifierIdentifier = result[2],
+      referencedSectionContent = '',
+      sectionContentReferenceTag = '<sg-insert>' + sectionContentIdentifier + sectionModifierIdentifier + '</sg-insert>';
+
+    if (index.hasOwnProperty(sectionContentIdentifier) && index[sectionContentIdentifier][property] !== 'undefined') {
+      referencedSectionContent = index[sectionContentIdentifier].markup;
+      // replace modifiers from referenced section
+      if (sectionModifierIdentifier !== '' && sectionModifierIdentifier.length > 1) {
+        sectionModifierIdentifier = sectionModifierIdentifier.substring(1);
+        // If all is the modifier insert all variants..
+        if (sectionModifierIdentifier === 'all') {
+          referencedSectionContent = index[sectionContentIdentifier].modifiers.reduce(reduceModifiers, '');
+        } else {
+          //Arrays start with 0, modifiers with 1 => subtract 1
+          sectionModifierIdentifier = parseInt(sectionModifierIdentifier, 10) - 1;
+          var modifiers = index[sectionContentIdentifier].modifiers;
+          // ..otherwise check if the modifier refered to exists
+          if (modifiers.hasOwnProperty(sectionModifierIdentifier) && modifiers[sectionModifierIdentifier].className !== 'undefined') {
+            var referencedModifierContent = index[sectionContentIdentifier].modifiers[sectionModifierIdentifier].className;
+            referencedSectionContent = referencedSectionContent.replace(modifierPlaceholder, referencedModifierContent);
+          }
+        }
+      }
+      referencedSectionContent = referencedSectionContent.replace(modifierPlaceholder, '');
+    }
+    if (referencedSectionContent === '') {
+      referencedSectionContent = '[ERROR: Referenced section ' + sectionContentIdentifier + ' has no markup!]';
+    } else if (referencedSectionContent.search(sectionContentReferenceTag) > 0) {
+      console.log('You can\'t reference a section that references the section back as this will end in an endless loop');
+      referencedSectionContent = '[ERROR: Reference to ' + sectionContentIdentifier + ' failed!]';
+    }
+    section[property] = section[property].replace(sectionContentReferenceTag, referencedSectionContent);
+
+    section.modifiers.forEach(replacer);
+  }
+}
+
 function replaceReferences(sections) {
   // TODO: Not to calculate twice
   var index = buildReferenceDictionary(sections);
   return sections.map(function(section) {
-    var sectionContentVariable = /<sg\-insert>([0-9\.]*)(.*)<\/sg\-insert>/,
-        result,
-        modifierPlaceholder = /\{\$modifiers\}/g,
-        finder = function (property) {
-          // Wrap modifiers
-          function replacerFactory (modifier) {
-            modifier.markup = modifier[property].replace(sectionContentReferenceTag, referencedSectionContent);
-            return modifier;
-          }
-          // Concat all modifiers
-          function reduceModifiers (previousValue, currentValue) {
-            return previousValue + currentValue[property].replace(modifierPlaceholder, currentValue.className);
-          }
-          while ((result = sectionContentVariable.exec(section[property]))) {
-            var sectionContentIdentifier = result[1],
-              sectionModifierIdentifier = result[2],
-              referencedSectionContent = '',
-              sectionContentReferenceTag = '<sg-insert>' + sectionContentIdentifier + sectionModifierIdentifier + '</sg-insert>';
-
-            if (index.hasOwnProperty(sectionContentIdentifier) && index[sectionContentIdentifier][property] !== 'undefined') {
-              referencedSectionContent = index[sectionContentIdentifier].markup;
-              // replace modifiers from referenced section
-              if (sectionModifierIdentifier !== '' && sectionModifierIdentifier.length > 1) {
-                sectionModifierIdentifier = sectionModifierIdentifier.substring(1);
-                // If all is the modifier insert all variants..
-                if (sectionModifierIdentifier === 'all') {
-                  referencedSectionContent = index[sectionContentIdentifier].modifiers.reduce(reduceModifiers, '');
-                } else {
-                  //Arrays start with 0, modifiers with 1 => subtract 1
-                  sectionModifierIdentifier = parseInt(sectionModifierIdentifier, 10) - 1;
-                  var modifiers = index[sectionContentIdentifier].modifiers;
-                  // ..otherwise check if the modifier refered to exists
-                  if (modifiers.hasOwnProperty(sectionModifierIdentifier) && modifiers[sectionModifierIdentifier].className !== 'undefined') {
-                    var referencedModifierContent = index[sectionContentIdentifier].modifiers[sectionModifierIdentifier].className;
-                    referencedSectionContent = referencedSectionContent.replace(modifierPlaceholder, referencedModifierContent);
-                  }
-                }
-              }
-              referencedSectionContent = referencedSectionContent.replace(modifierPlaceholder, '');
-            }
-            if (referencedSectionContent === '') {
-              referencedSectionContent = '[ERROR: Referenced section ' + sectionContentIdentifier + ' has no markup!]';
-            } else if (referencedSectionContent.search(sectionContentReferenceTag) > 0) {
-              console.log('You can\'t reference a section that references the section back as this will end in an endless loop');
-              referencedSectionContent = '[ERROR: Reference to ' + sectionContentIdentifier + ' failed!]';
-            }
-            section[property] = section[property].replace(sectionContentReferenceTag, referencedSectionContent);
-
-            section.modifiers.forEach(replacerFactory);
-          }
-        };
-    finder('markup');
-    finder('sg-wrapper');
+    findeAndReplace(section, 'markup', index);
+    findeAndReplace(section, 'sg-wrapper', index);
     return section;
   });
 }

--- a/test/unit/modules/section-references.test.js
+++ b/test/unit/modules/section-references.test.js
@@ -36,6 +36,7 @@ describe('Processing section references in the markup', () => {
 <sg-insert>4.1-10</sg-insert>`,
     section[8] = {},
     section[8].markup = `<sg-insert>4.1-all</sg-insert>`;
+    section[8]['sg-wrapper'] = `<sg-insert>1.0</sg-insert>`;
 
     json = {
       sections: [{
@@ -97,7 +98,8 @@ describe('Processing section references in the markup', () => {
           description: '',
           reference: '4.3',
           modifiers: [],
-          markup: section[8].markup
+          markup: section[8].markup,
+          'sg-wrapper': section[8]['sg-wrapper']
       }]
     };
     json.sections = replaceSectionReferences(json.sections);
@@ -127,5 +129,8 @@ describe('Processing section references in the markup', () => {
     var replacedRefs = '<div style="background:modifier1;">modifier1</div><div style="background:modifier2;">modifier2</div>';
     expect(removeLinebreaks(json.sections[8].markup)).eql(replacedRefs);
   });
-
+  it('should replace section reference in sg-wrapper', () => {
+    var replacedRefs = '<div>1.0</div>';
+    expect(removeLinebreaks(json.sections[8]['sg-wrapper'])).eql(replacedRefs);
+  });
 });


### PR DESCRIPTION
This pr should fix https://github.com/SC5/sc5-styleguide/issues/748

Previously the sectionRefrence.replaceReferences function only replaced sg-includes in the markup variable of the given sections. Now includes are replaced in the 'sg-wrapper' variable as well. 

This test input: 
```
// List item
//
// markup:
// <li>Item</li>
//
// Styleguide 4.0.1
li {
  color: red;
}

// List footer
//
// markup:
// <div>
//   <p>hej</p>
// </div>
//
// sg-wrapper:
// <ul>
//   <li>hop</li>
//   <sg-insert>4.0.1</sg-insert>
// </ul>
// <sg-wrapper-content/>
//
// Styleguide 4.0.2
```

Without the fix the styles are rendered like this:
![broken](https://cloud.githubusercontent.com/assets/7137840/11418137/b40072a6-9425-11e5-8658-4729d7a5adfd.png)

When the contents in the sg-wrapper is replaced the same styles are rendered like this:
![fixed](https://cloud.githubusercontent.com/assets/7137840/11418147/d7d40986-9425-11e5-9416-ce03994ec2a3.png)

