### PR TITLE
Jade cache, level 2 

### DIFF
--- a/lib/styleguide.js
+++ b/lib/styleguide.js
@@ -39,7 +39,7 @@ var path = require('path'),
   sgServer = require('./server'),
   distPath = path.join(__dirname, 'dist'),
   fileHashes = {},
-  jadeCache = {},
+  jadeCache,
   serverInstance;
 
 function socketIsOpen() {
@@ -103,7 +103,7 @@ function generateJadeMarkup(json, options) {
 
   var parentref;
   function convertToJade(section) {
-    var cacheKey;
+    var cacheKey, jadestring, md5;
 
     if (!section.markup) { return; }
     if (/<[a-z][\s\S]*>/i.test(section.markup)) { return; }
@@ -117,11 +117,17 @@ function generateJadeMarkup(json, options) {
       cacheKey = parentref + ' - ' + section.name;
     }
 
-    if (jadeCache.getItem(cacheKey)) {
-      section.markup = jadeCache.getItem(cacheKey);
+    jadestring = bemtoinclude + section.markup;
+    md5 = crypto.createHash('md5').update(jadestring).digest('hex');
+
+    if (jadeCache.getItem(cacheKey) && jadeCache.getItem(cacheKey).key === md5) {
+      section.markup = jadeCache.getItem(cacheKey).value;
     } else {
-      section.markup = jade.render(bemtoinclude + section.markup, jadeOptions);
-      jadeCache.setItem(cacheKey, section.markup);
+      section.markup = jade.render(jadestring, jadeOptions);
+      jadeCache.setItem(cacheKey, {
+        key : md5,
+        value : section.markup
+      });
     }
 
     if (section.modifiers) {

--- a/lib/styleguide.js
+++ b/lib/styleguide.js
@@ -23,6 +23,7 @@ var path = require('path'),
   minimatch = require('minimatch'),
   fs = require('fs-extra'),
   File = require('vinyl'),
+  LocalCache = require('node-localcache'),
   crypto = require('crypto'),
   Q = require('q'),
   _ = require('lodash'),
@@ -87,11 +88,12 @@ function groupModuleFiles(allModules) {
   });
 }
 
-function generateJadeMarkup(json) {
+function generateJadeMarkup(json, options) {
+  jadeCache = new LocalCache(path.resolve(options.rootPath, 'jadecache.json'));
 
   // path to bemto
   var bemtoinclude = 'include ./node_modules/bemto.jade/bemto.jade\n',
-      options = {
+      jadeOptions = {
         filename: __dirname,
         compileDebug: true,
         pretty: true
@@ -99,15 +101,27 @@ function generateJadeMarkup(json) {
 
   _.each(json.sections, convertToJade);
 
+  var parentref;
   function convertToJade(section) {
+    var cacheKey;
+
     if (!section.markup) { return; }
     if (/<[a-z][\s\S]*>/i.test(section.markup)) { return; }
 
     section.markupJade = section.markup;
-    if (jadeCache[bemtoinclude + section.markup]) {
-      section.markup = jadeCache[bemtoinclude + section.markup];
+
+    if (section.reference) {
+      parentref = section.reference;
+      cacheKey = section.reference;
     } else {
-      section.markup = jadeCache[bemtoinclude + section.markup] = jade.render(bemtoinclude + section.markup, options);
+      cacheKey = parentref + ' - ' + section.name;
+    }
+
+    if (jadeCache.getItem(cacheKey)) {
+      section.markup = jadeCache.getItem(cacheKey);
+    } else {
+      section.markup = jade.render(bemtoinclude + section.markup, jadeOptions);
+      jadeCache.setItem(cacheKey, section.markup);
     }
 
     if (section.modifiers) {
@@ -276,7 +290,7 @@ module.exports.generate = function(options) {
           });
         }
 
-        options.enableJade && generateJadeMarkup(styleguide);
+        options.enableJade && generateJadeMarkup(styleguide, options);
         replaceSectionReferences(styleguide);
         generateSectionWrapperMarkup(styleguide);
         copyUsedOptionsToJsonConfig(opt, styleguide);
@@ -358,12 +372,12 @@ module.exports.generate = function(options) {
             emitCompileSuccess();
           })
           .catch(function(error) {
-            console.error(error.toString());
+            console.error(error.stack);
             emitCompileError(error);
           })
           .finally(callback);
       }).catch(function(error) {
-        console.error(error.toString());
+        console.error(error.stack);
         emitCompileError(error);
         callback();
       });

--- a/package.json
+++ b/package.json
@@ -29,13 +29,14 @@
     "README.md"
   ],
   "dependencies": {
+    "basic-auth-connect": "~1.0.0",
+    "bemto.jade": "0.2.2",
     "body-parser": "~1.14.1",
     "chalk": "~1.1.1",
     "cheerio": "^0.19.0",
     "cookie-parser": "~1.4.0",
     "css": "~2.2.0",
     "express": "~4.13.0",
-    "basic-auth-connect": "~1.0.0",
     "fs-extra": "^0.26.2",
     "gonzales-pe": "3.0.0-31",
     "gulp": "~3.9.0",
@@ -46,11 +47,13 @@
     "gulp-replace": "^0.5.3",
     "gulp-sass": "~2.1.0",
     "gulp-util": "~3.0.5",
+    "jade": "^1.8.1",
     "kss": "~2.1.0",
     "lodash": "~3.10.1",
     "markdown-it": "^5.0.2",
     "minimatch": "~3.0.0",
     "morgan": "~1.6.0",
+    "node-localcache": "^0.1.3",
     "node-neat": "~1.7.2",
     "postcss": "^5.0.12",
     "q": "~1.4.1",
@@ -59,9 +62,7 @@
     "through2": "~2.0.0",
     "vinyl": "~1.1.0",
     "vinyl-fs": "~2.2.1",
-    "yargs": "~3.30.0",
-    "jade": "^1.8.1",
-    "bemto.jade": "0.2.2"
+    "yargs": "~3.30.0"
   },
   "devDependencies": {
     "babel": "^6.1.18",


### PR DESCRIPTION
### Changes:
 - Since now, jade compiled markup are cached between launches (got a headache on huge project).
 - JS Errors now prints callstack, instead of naked error message itself

### How it works:
I have added LocalCache lib, with same api like LocalStorage. It store all cached data to `.json` file (rootPath + 'jadecache.json'). File creating only with `jadeEnabled` : `true` flag.