### PR TITLE
Fix #904. Updating the babel package.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,3 @@
 {
-  "presets": ["es2015"],
-  "plugins": [
-    "babel-root-import"
-  ]
+  "presets": ["es2015"]
 }

--- a/package.json
+++ b/package.json
@@ -77,10 +77,9 @@
     "yargs": "~3.30.0"
   },
   "devDependencies": {
-    "babel": "^6.1.18",
-    "babel-core": "^6.2.1",
+    "babel-core": "^6.7.2",
     "babel-preset-es2015": "^6.1.18",
-    "babel-root-import": "^3.0.1",
+    "babel-register": "^6.7.2",
     "chai": "~3.4.1",
     "conventional-changelog": "git://github.com/sc5/conventional-changelog.git#features/sc-styleguide",
     "coveralls": "~2.11.2",
@@ -99,6 +98,7 @@
     "gulp-rimraf": "^0.2.0",
     "istanbul": "~0.4.1",
     "jscs": "~2.6.0",
+    "jshint": "~2.9.1",
     "karma": "~0.13.15",
     "karma-coverage": "~0.5.3",
     "karma-mocha": "~0.2.1",
@@ -110,8 +110,7 @@
     "proxyquire": "~1.7.3",
     "requirefrom": "~0.2.0",
     "sinon": "~1.17.2",
-    "sinon-chai": "~2.8.0",
-    "jshint": "~2.9.1"
+    "sinon-chai": "~2.8.0"
   },
   "scripts": {
     "pretest": "gulp clean-coverage",

--- a/test/unit/modules/cli/index.test.js
+++ b/test/unit/modules/cli/index.test.js
@@ -1,0 +1,19 @@
+'use strict';
+
+import chai, { expect } from 'chai';
+import sinonChai from 'sinon-chai';
+import index from '~/lib/modules/cli/index';
+import argv from '~/lib/modules/cli/argv';
+import styleguide from '~/lib/modules/cli/styleguide-cli';
+
+chai.use(sinonChai);
+
+describe('index', () => {
+    it('should load argv.js', () => {
+        expect(index.argv).to.deep.eql(argv);
+    });
+
+    it('should load styleguide-cli.js', () => {
+        expect(index.styleguide).to.deep.eql(styleguide);
+    });
+});

--- a/test/unit/modules/cli/styleguide-cli.test.js
+++ b/test/unit/modules/cli/styleguide-cli.test.js
@@ -1,0 +1,33 @@
+'use strict';
+
+import chai, { expect } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import styleguide from '~/lib/modules/cli/styleguide-cli';
+import gulp from 'gulp';
+
+chai.use(sinonChai);
+
+describe('styleguide-cli', () => {
+
+    var spy = sinon.spy(console, 'error');
+
+    it('should be a function', () => {
+        expect(styleguide).to.be.a('function');
+    });
+
+    it('should error when no arguments are supplied', () => {
+        styleguide();
+        expect(spy.called).to.be.true;
+    });
+
+    it('should create gulp tasks', () => {
+        styleguide();
+        expect(gulp.tasks).to.contain.all.keys([
+            'styleguide:generate',
+            'styleguide:applystyles',
+            'watch:kss',
+            'watch:styles'
+        ]);
+    });
+});


### PR DESCRIPTION
With Babel 6 removing the babel package, switched to babel-core.
Removed babel-root-import plugin that includes the older babel package.
Added some tests to get pull approved.