### PR TITLE
Add possibility to have includes in jade markup

### DIFF
--- a/lib/styleguide.js
+++ b/lib/styleguide.js
@@ -94,6 +94,7 @@ function generateJadeMarkup(json, options) {
   var bemtoinclude = 'include ./node_modules/bemto.jade/bemto.jade\n',
       jadeOptions = {
         filename: __dirname,
+        basedir: process.cwd(),
         compileDebug: true,
         pretty: true
       };


### PR DESCRIPTION
This is basically a quick fix to make sure you can have includes from your project in the jade markup of a component.

This sets the root for all absolute paths to the main folder of your app so that you can use absolutes to set up includes in your jade markup.

