### PR TITLE
Make the catch log the right error in case of syntax parsing error

### DIFF
--- a/lib/styleguide.js
+++ b/lib/styleguide.js
@@ -409,7 +409,7 @@ module.exports.generate = function(options) {
           })
           .finally(callback);
       }).catch(function(error) {
-        console.error(error.stack);
+        console.error("Error Found in syntax parsing", error);
         emitCompileError(error);
         callback();
       });

--- a/lib/styleguide.js
+++ b/lib/styleguide.js
@@ -409,7 +409,7 @@ module.exports.generate = function(options) {
           })
           .finally(callback);
       }).catch(function(error) {
-        console.error("Error Found in syntax parsing", error);
+        console.error('Error Found in syntax parsing', error);
         emitCompileError(error);
         callback();
       });


### PR DESCRIPTION
I caught a problem where my syntax was causing an error in the code generation.
The problem was with less, with a line that looked like: 

```less
width: calc(~"100%" - @myvar); 
```

The only log I was getting was "undefined" since it was logging ```error.stack``` but that error does not have a stack.

This change shows the full error so that user get more info on what went wrong when it happens there.

There is a problem with less processing too somehow but we need to identify it properly to create an issue for it