### PR TITLE
Update styleguide.js

### DIFF
--- a/lib/styleguide.js
+++ b/lib/styleguide.js
@@ -404,12 +404,12 @@ module.exports.generate = function(options) {
             emitCompileSuccess();
           })
           .catch(function(error) {
-            console.error(error.stack);
+            console.error(error.stack || error);
             emitCompileError(error);
           })
           .finally(callback);
       }).catch(function(error) {
-        console.error(error.stack);
+        console.error(error.stack || error);
         emitCompileError(error);
         callback();
       });


### PR DESCRIPTION
Prevent "undefined" as the only error message in your log when something is wrong with your css