### PR TITLE
Show only the exception message on compile error

### DIFF
--- a/lib/styleguide.js
+++ b/lib/styleguide.js
@@ -404,12 +404,12 @@ module.exports.generate = function(options) {
             emitCompileSuccess();
           })
           .catch(function(error) {
-            console.error(error.stack || error);
+            console.error(error.stack || error.message);
             emitCompileError(error);
           })
           .finally(callback);
       }).catch(function(error) {
-        console.error(error.stack || error);
+        console.error(error.stack || error.message);
         emitCompileError(error);
         callback();
       });


### PR DESCRIPTION
... instead of dumping the whole exception object