### PR TITLE
optimize filter setVariables

### DIFF
--- a/lib/app/js/app.js
+++ b/lib/app/js/app.js
@@ -165,8 +165,8 @@ angular.module('sgApp', [
     };
   })
   // Replace $variables with values found in variables object
-  .filter('setVariables', function() {
-    return function(str, variables) {
+  .filter('setVariables', ['lodash', function(_) {
+    function filterFn(str, variables) {
       if (!str) {
         return '';
       }
@@ -193,5 +193,6 @@ angular.module('sgApp', [
         str = str.replace(new RegExp('\[\$\@]' + variable.name, 'g'), cleanedValue);
       });
       return str;
-    };
-  });
+    }
+    return _.memoize(filterFn);
+  }]);


### PR DESCRIPTION
Updated pull request: 
We have quite large styleguide and seems that setVariables filter have some performance problems. 
Our variables arrays has almost 300 items and using _.memoize in some pages we can reduce cpu 100% usage from ~65s -> ~2.5s.