### PR TITLE
Return server instance when calling styleguide.server()

### DIFF
--- a/lib/styleguide.js
+++ b/lib/styleguide.js
@@ -497,13 +497,13 @@ module.exports.applyStyles = function() {
 /* Built-in server */
 
 module.exports.server = function(options) {
-  startServer(options);
+  return startServer(options);
 };
 
 function startServer(options) {
-  var port = options.port;
   // Ignore start server if we already have instance running
   if (!serverInstance) {
+    var port = options.port;
     serverInstance = sgServer(options);
     serverInstance.app.set('port', port);
     serverInstance.server.listen(serverInstance.app.get('port'), function() {


### PR DESCRIPTION
The `styleguide.server()` method should return the instance of the `sgServer` to do further optimizations to it.