### PR TITLE
Fixes #42. Scrolling from javascript not working when overflow: auto is set on body.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,5 +17,8 @@
     "custom-event": "^0.1.0",
     "angular-ui-router": "ui-router#^0.2.18"
   },
-  "devDependencies": {}
+  "devDependencies": {},
+  "resolutions": {
+    "angular": "1.5.5"
+  }
 }

--- a/lib/app/css/styleguide-app.css
+++ b/lib/app/css/styleguide-app.css
@@ -23,7 +23,6 @@ html,
 body.sg {
   width: 100%;
   height: 100%;
-  overflow: auto;
 }
 
 .sg.view-index {


### PR DESCRIPTION
It was not a angular issue - all things are there to enable smooth scrolling using anchor links. It was a css thing that causes js based scrolling not to work.