### PR TITLE
Fix angular-mocks version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "highlightjs": "^9.2.0",
     "angular": "1.5.5",
     "angular-animate": "1.5.5",
-    "angular-mocks": "^1.5.5",
+    "angular-mocks": "1.5.5",
     "angular-highlightjs": "^0.6.1",
     "angular-bootstrap-colorpicker": "^3.0.25",
     "angular-local-storage": "^0.2.7",


### PR DESCRIPTION
I noticed that my recent PR to upgrade the project dependencies allowed angular-mocks to get out of sync with angular and angular-animate. This caused an issue when I did a fresh install today and the angular versions got out of sync. This PR makes sure that the angular-mocks version exactly matches angular.