### PR TITLE
Avoid nested paragraphs in description

### DIFF
--- a/lib/app/views/partials/section.html
+++ b/lib/app/views/partials/section.html
@@ -11,7 +11,7 @@
     </a>
   </header>
   <div class="sg sg-section-partial" ng-if="section.modifiers.length || section.description">
-    <p class="sg sg-section-description" ng-bind-html="section.description | unsafe"></p>
+    <div class="sg sg-section-description" ng-bind-html="section.description | unsafe"></div>
     <ul ng-if="section.modifiers.length" class="sg modifier-list">
       <li class="sg-item" ng-repeat="mod in section.modifiers">
         <strong ng-bind-html="mod.name | unsafe"></strong> - <span ng-bind-html="mod.description | unsafe"></span>


### PR DESCRIPTION
A multi-block description already creates as many paragraphs as there are "blocks" of description and the partial view `section.html` nests it in a parent paragraph, which is invalid HTML and may cause several problem (with browser parsers, with screen-readers and other assistive technologies).

Changing container `.sg-section-description` for a `div` avoids nested `p`.

Example with this 3 paragraphs-long description:
```
// Title of section
//
// Paragraph 1
//
// Paragraph 2
//
// Paragraph 3
//
// markup: (…)
```
would now result in:
```
<div ng-bind-html="section.description |&nbsp;unsafe" class="sg sg-section-description ng-binding">
  <p class="sg">Paragraph 1</p>
  <p class="sg">Paragraph 2</p>
  <p class="sg">Paragraph 3</p>
</div>
```
With this modification, single-line descriptions are still parsed as a single paragraph `p.sg` and have this div as a container so both cases (single and multi-paragraphs descriptions) are fine.