### PR TITLE
Removed appRoot property from socket.io script src to stop 404

### DIFF
--- a/lib/app/index.html
+++ b/lib/app/index.html
@@ -57,7 +57,7 @@
   <script src="{{{appRoot}}}/js/vendor.js"></script>
   <script src="{{{appRoot}}}/js/app.js"></script>
   {{#socketIo}}
-    <script src="{{{appRoot}}}/socket.io/socket.io.js"></script>
+    <script src="/socket.io/socket.io.js"></script>
   {{/socketIo}}
   {{{afterBody}}}
 </body>


### PR DESCRIPTION
See issue 988 for details
https://github.com/SC5/sc5-styleguide/issues/988