### PR TITLE
Fix to return the ocLazyLoading promise on resolve

### DIFF
--- a/lib/app/js/app.js
+++ b/lib/app/js/app.js
@@ -42,7 +42,7 @@ angular.module('sgApp', deps)
         controller: 'SectionsCtrl',
         resolve: {
           loadLazyModule: function($ocLazyLoad) {
-            loadModule($ocLazyLoad);
+            return loadModule($ocLazyLoad);
           }
         }
       })
@@ -52,7 +52,7 @@ angular.module('sgApp', deps)
         controller: 'SectionsCtrl',
         resolve: {
           loadLazyModule: function($ocLazyLoad) {
-            loadModule($ocLazyLoad);
+            return loadModule($ocLazyLoad);
           }
         }
       })
@@ -82,7 +82,7 @@ angular.module('sgApp', deps)
         controller: 'VariablesCtrl',
         resolve: {
           loadLazyModule: function($ocLazyLoad) {
-            loadModule($ocLazyLoad);
+            return loadModule($ocLazyLoad);
           }
         }
       })
@@ -92,7 +92,7 @@ angular.module('sgApp', deps)
         controller: 'ElementCtrl',
         resolve: {
           loadLazyModule: function($ocLazyLoad) {
-            loadModule($ocLazyLoad);
+            return loadModule($ocLazyLoad);
           }
         }
       }).state('app.index.404', {

--- a/lib/app/js/app.js
+++ b/lib/app/js/app.js
@@ -41,8 +41,8 @@ angular.module('sgApp', deps)
         templateUrl: 'views/sections.html',
         controller: 'SectionsCtrl',
         resolve: {
-          loadLazyModule: function($ocLazyLoad) {
-            return loadModule($ocLazyLoad);
+          loadLazyModule: function($$animateJs, $ocLazyLoad) {
+            return loadModule($$animateJs, $ocLazyLoad);
           }
         }
       })
@@ -51,8 +51,8 @@ angular.module('sgApp', deps)
         templateUrl: 'views/sections.html',
         controller: 'SectionsCtrl',
         resolve: {
-          loadLazyModule: function($ocLazyLoad) {
-            return loadModule($ocLazyLoad);
+          loadLazyModule: function($$animateJs, $ocLazyLoad) {
+            return loadModule($$animateJs, $ocLazyLoad);
           }
         }
       })
@@ -81,8 +81,8 @@ angular.module('sgApp', deps)
         templateUrl: 'views/variable-sections.html',
         controller: 'VariablesCtrl',
         resolve: {
-          loadLazyModule: function($ocLazyLoad) {
-            return loadModule($ocLazyLoad);
+          loadLazyModule: function($$animateJs, $ocLazyLoad) {
+            return loadModule($$animateJs, $ocLazyLoad);
           }
         }
       })
@@ -91,8 +91,8 @@ angular.module('sgApp', deps)
         templateUrl: 'views/element-fullscreen.html',
         controller: 'ElementCtrl',
         resolve: {
-          loadLazyModule: function($ocLazyLoad) {
-            return loadModule($ocLazyLoad);
+          loadLazyModule: function($$animateJs, $ocLazyLoad) {
+            return loadModule($$animateJs, $ocLazyLoad);
           }
         }
       }).state('app.index.404', {
@@ -100,7 +100,7 @@ angular.module('sgApp', deps)
         templateUrl: 'views/404.html'
       });
 
-    function loadModule($ocLazyLoad) {
+    function loadModule($$animateJs, $ocLazyLoad) {
       if (window.filesConfig && window.filesConfig.length) {
         var moduleNames = [];
         angular.forEach(window.filesConfig, function(lazyLoadmodule) {


### PR DESCRIPTION
When you add your own directives in the filesConfig property, they are loaded via ocLazyLoad in the resolve property for every $state in the Styleguide App. 

error: as the ocLazyLoading promise is not being returned in the resolve, you might experience some weird errors saying that  your directives are not defined, also, when you reload the browser, sometimes you will experience an error with $$animateJS 

the $$animateJS error is related to https://github.com/angular/angular.js/issues/14291

also, I added the return statement in the resolve property to return the ocLazyLoad promise so the view will not be printed until all the modules are loaded.
