### PR TITLE
Fixed a styleguide styling issue regarding the $content-max-width scss variable

### DIFF
--- a/lib/app/css/styleguide-app.css
+++ b/lib/app/css/styleguide-app.css
@@ -351,7 +351,7 @@ Styleguide 3.1.1
 .sg.sg-wrapper {
   position: relative;
   overflow: hidden;
-  max-width: 68em;
+  max-width: $content-max-width;
   margin: 0 auto;
   padding: $wrapper-vertical-padding $content-margin $wrapper-vertical-padding $min-content-margin;
   @media (--mobile) {
@@ -397,7 +397,7 @@ Styleguide 3.1.1
       overflow: scroll;
       transition: opacity .4s cubic-bezier(0.000, 0.995, 0.990, 1.000);
     }
-    
+
     .sg.option {
       text-align: center;
       a {


### PR DESCRIPTION
Fixed an issue where overriding the $content-max-width SCSS variable using the 'customColors' config property was not having an effect on the .sg-wrapper CSS class because of a hard-coded value.