### PR TITLE
Fix layout and mobile toggle for sidenav  option

### DIFF
--- a/lib/app/css/styleguide-app.css
+++ b/lib/app/css/styleguide-app.css
@@ -349,12 +349,15 @@ Styleguide 3.1.1
 }
 
 .sg.sg-wrapper {
+  align-items: stretch;
+  display: flex;
   position: relative;
   overflow: hidden;
   max-width: $content-max-width;
   margin: 0 auto;
   padding: $wrapper-vertical-padding $content-margin $wrapper-vertical-padding $min-content-margin;
   @media (--mobile) {
+    display: block;
     padding: 0;
   }
   &.designerToolVisible {
@@ -384,19 +387,16 @@ Styleguide 3.1.1
   }
 
   .sg.sg-side-nav {
-    display: none;
-    float: left;
     display: inline-block;
     width: 30%;
     opacity: 1;
-    height: 500px;
-    overflow-y: scroll;    
+    overflow-y: auto;
     @media (--mobile) {
+      height: 500px;
       width: 100%;
       padding-top: 30px;
       z-index: 99999;
       background: #8b8b8b;
-      overflow: scroll;
       transition: opacity .4s cubic-bezier(0.000, 0.995, 0.990, 1.000);
     }
 

--- a/lib/app/views/main.html
+++ b/lib/app/views/main.html
@@ -69,7 +69,7 @@
   <div class="sg side-nav-toggle" ng-click="toggleSideNav(toggleMenu)">
     {{ toggleMenu ? "&gt;&gt;" : "&lt;&lt;" }}
   </div>
-  <nav class="sg sg-side-nav" ng-class="{ 'animate-show': toggleMenu}">
+  <nav class="sg sg-side-nav" ng-class="{ 'animate-show': toggleMenu}" ng-if="! toggleMenu">
     <ul class="sg sg-nav-section">
       <li class="sg sg-nav-item">
         <a class="sg sg-nav-link"


### PR DESCRIPTION
I use the sidenav option a lot for large styleguides. The layout had a set overflow with scrollbars always showing and was cumbersome to navigate. This commit ensures adequate vertical space for the sidenav, removes persistent scrollbars, and toggles correctly in mobile views. Tested in Chrome, Firefox, Safari, Edge, and IE 11.