### PR TITLE
Update README.md Grunt Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ grunt.initConfig({
         .pipe(gulp.dest(outputPath));
     },
     'styleguide-applystyles': function() {
-      gulp.src('main.scss')
+      return gulp.src('main.scss')
         .pipe(styleguide.applyStyles())
         .pipe(gulp.dest('output'));
     }


### PR DESCRIPTION
Without the return styleguide.applystyles() never creates the following files:
* styleguide.css
* styleguide_pseudo_styles.css
* styleguide_at_rules.css