### PR TITLE
Output meaningful error message to the console; fixes #1054

### DIFF
--- a/lib/styleguide.js
+++ b/lib/styleguide.js
@@ -427,12 +427,12 @@ module.exports.generate = function(options) {
             emitCompileSuccess();
           })
           .catch(function(error) {
-            console.error(error.stack || error.message);
+            console.error(error.toString());
             emitCompileError(error);
           })
           .finally(callback);
       }).catch(function(error) {
-        console.error(error.stack || error.message);
+        console.error(error.toString());
         emitCompileError(error);
         callback();
       });


### PR DESCRIPTION
This PR addresses #1054 by printing out a helpful error message to the console using gonzales-pe `error.toString()` method.