### PR TITLE
Feaure/update angular version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,23 +2,23 @@
   "name": "styleguide",
   "version": "0.1.0",
   "dependencies": {
-    "highlightjs": "^9.2.0",
-    "angular": "1.5.5",
-    "angular-animate": "1.5.5",
-    "angular-mocks": "1.5.5",
-    "angular-highlightjs": "^0.6.1",
-    "angular-bootstrap-colorpicker": "^3.0.25",
-    "angular-local-storage": "^0.2.7",
-    "oclazyload": "^1.0.9",
+    "highlightjs": "^9.10.0",
+    "angular": "1.6.4",
+    "angular-animate": "1.6.4",
+    "angular-mocks": "1.6.4",
+    "angular-highlightjs": "^0.7.1",
+    "angular-bootstrap-colorpicker": "^3.0.28",
+    "angular-local-storage": "^0.5.2",
+    "oclazyload": "^1.1.0",
     "ngprogress": "^1.1.3",
-    "angular-debounce": "^1.0.3",
+    "angular-debounce": "^1.1.0",
     "angular-scroll": "^1.0.0",
-    "lodash": "^4.11.2",
+    "lodash": "^4.17.4",
     "custom-event": "^0.1.0",
-    "angular-ui-router": "ui-router#^0.2.18"
+    "angular-ui-router": "^0.4.2"
   },
   "devDependencies": {},
   "resolutions": {
-    "angular": "1.5.5"
+    "angular": "1.6.4"
   }
 }

--- a/lib/app/js/services/Styleguide.js
+++ b/lib/app/js/services/Styleguide.js
@@ -24,10 +24,10 @@ angular.module('sgApp')
       return $http({
         method: 'GET',
         url: 'styleguide.json'
-      }).success(function(response) {
-        _this.config.data = response.config;
-        _this.variables.data = response.variables;
-        _this.sections.data = response.sections;
+      }).then(function(response) {
+        _this.config.data = response.data.config;
+        _this.variables.data = response.data.variables;
+        _this.sections.data = response.data.sections;
 
         if (!Socket.isConnected()) {
           Socket.connect();


### PR DESCRIPTION
Update the dependencies of the app, to their latest version. Within this, updates angular to 1.6.x.

In #1072 I suggested this roadmap to update the angular version:

> * Have a branch to handle the updates of angular, which could be published to npm with a @next or beta label or so. This way it would be available for people that need it
> * Add deprecation warnings about breaking changes, so the users have time to fix whatever needs to be fixed
> * Add a note about the update in the readme

However, after having worked in the update, I realized that the proposed workflow is not required, because there are no breaking changes that might affect users of the project. 

The only change relevant is in this commit:
https://github.com/DanielaValero/sc5-styleguide/commit/3fa0c39d6d134d5fd71f415a94678459a7ef836f

Which will not affect users, as is in a function that is encapsulated in the project.

Closes #1072