### PR TITLE
allow .pug files to be passed into markup

### DIFF
--- a/lib/modules/kss-parser.js
+++ b/lib/modules/kss-parser.js
@@ -16,7 +16,7 @@ function jsonSections(sections, block) {
   return sections.map(function(section) {
     // Temporary inserting of partial
     var partial = section;
-    if (partial.markup() && partial.markup().toString().match(/^[^\n]+\.(html|hbs)$/)) {
+    if (partial.markup() && partial.markup().toString().match(/^[^\n]+\.(html|hbs|pug)$/)) {
       partial.file = partial.markup().toString();
       partial.name = path.basename(partial.file, path.extname(partial.file));
       partial.file = path.dirname(block.filePath) + '/' + partial.file;


### PR DESCRIPTION
since sc5 comes baked in with pug/jade, it would only make sense to allow for .pug files to be passed in like html or hbs files.

@varya 