### PR TITLE
fix(package.json) fix failing test suite

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "karma-phantomjs-launcher": "~1.0.0",
     "karma-sinon-chai": "~1.1.0",
     "main-bower-files": "~2.9.0",
+    "mocha": "^3.5.3",
     "node-localcache": "^0.1.3",
     "phantomjs-prebuilt": "2.1.7",
     "proxyquire": "~1.7.3",


### PR DESCRIPTION
- Fix missing `mocha` package devDependency that was causing test suite to fail to work.

Reason for the change:
- Test suite fails without of the required dependencies.

Related issue:
- https://github.com/SC5/sc5-styleguide/issues/1117
  - _"Test suite fails to run without mocha dependency"_